### PR TITLE
ruby: use ruby's built-in support to test for infinity and nan

### DIFF
--- a/bindings/ruby/lib/base/float.rb
+++ b/bindings/ruby/lib/base/float.rb
@@ -1,15 +1,15 @@
 if !defined?(Infinity)
-    Infinity = 1e200 ** 200
+    Infinity = Float::INFINITY
 end
 if !defined?(NaN)
-    NaN = Infinity / Infinity
+    NaN = Float::NAN
 end
 
 module Base
-    def self.infinity?(v); v == Infinity end
-    def self.infinity; Infinity end
-    def self.nan?(v); v != v end
-    def self.nan; NaN end
+    def self.infinity?(v); v.to_f.infinite? end
+    def self.infinity; Float::INFINITY end
+    def self.nan?(v); v.to_f.nan? end
+    def self.nan; Float::NAN end
     def self.unknown?(v); nan?(v) end
     def self.unknown; nan end
     def self.unset?(v); nan?(v) end


### PR DESCRIPTION
Ruby's Float class already has constants to define NaN and Infinity as well as built-in support to test whether a float is a nan or an infinity. Use them instead of our own custom-made code.
