### PR TITLE
test: depend on minitest only

### DIFF
--- a/bindings/ruby/test/test_float.rb
+++ b/bindings/ruby/test/test_float.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'base/float'
 
-class TC_Float < Test::Unit::TestCase
+class TC_Float < Minitest::Test
     def test_special_values
         assert Base.infinity?(Infinity)
         assert Base.nan?(NaN)

--- a/bindings/ruby/test/test_isometry3.rb
+++ b/bindings/ruby/test/test_isometry3.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'eigen'
 
-class TC_Eigen_Isometry3 < Test::Unit::TestCase
+class TC_Eigen_Isometry3 < Minitest::Test
     def test_base
         v = Eigen::Vector3.new(1, 2, 3)
 	q = Eigen::Quaternion.new(1, 0, 0, 0)

--- a/bindings/ruby/test/test_matrixx.rb
+++ b/bindings/ruby/test/test_matrixx.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'eigen'
 
-class TC_Eigen_MatrixX < Test::Unit::TestCase
+class TC_Eigen_MatrixX < Minitest::Test
     def test_base
         m = Eigen::MatrixX.new(2,3)
         assert_equal(m.rows, 2)

--- a/bindings/ruby/test/test_quaternion.rb
+++ b/bindings/ruby/test/test_quaternion.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'eigen'
 
-class TC_Eigen_Quaternion < Test::Unit::TestCase
+class TC_Eigen_Quaternion < Minitest::Test
     def test_base
         v = Eigen::Quaternion.new(0, 1, 2, 3)
         assert_equal(0, v.w)

--- a/bindings/ruby/test/test_spline.rb
+++ b/bindings/ruby/test/test_spline.rb
@@ -1,9 +1,7 @@
-$LOAD_PATH.unshift File.expand_path("../lib", File.dirname(__FILE__))
-
-require 'test/unit'
+require 'minitest/autorun'
 require 'base/geometry/spline'
 
-class TC_Geometry_Spline < Test::Unit::TestCase
+class TC_Geometry_Spline < Minitest::Test
     def test_base
         v = Types::Base::Geometry::Spline.new(3)
         assert_equal 3, v.dimension

--- a/bindings/ruby/test/test_vector3.rb
+++ b/bindings/ruby/test/test_vector3.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'eigen'
 
-class TC_Eigen_Vector3 < Test::Unit::TestCase
+class TC_Eigen_Vector3 < Minitest::Test
     def test_base
         v = Eigen::Vector3.new(1, 2, 3)
         assert_equal(1, v.x)


### PR DESCRIPTION
There's a collision between ruby's built-in minitest library and the
gem (they are incompatible), which breaks testrb and testing in general.

Switch to using only minitest. This is already what the RockRuby cmake code was expecting (it ran tests using ruby -rminitest/autorun instead of testrb)
