### PR TITLE
Fix base temperature

### DIFF
--- a/base/Temperature.hpp
+++ b/base/Temperature.hpp
@@ -2,7 +2,7 @@
 #define __BASE_TEMPERATURE_HH__
 
 #include <boost/format.hpp>
-#include <math.h>
+#include <complex>      // std::abs
 
 namespace base
 {
@@ -107,7 +107,7 @@ public:
      */
     bool inline isApprox( Temperature other, double prec = 1e-5 ) const
     {
-	return fabs( other.kelvin - kelvin ) < prec;
+	return std::abs( other.kelvin - kelvin ) < prec;
     }
 
     void operator=(const Temperature &other)


### PR DESCRIPTION
Note: The header is not broken, just badly written.

Removing the includes to `Eigen.hpp` and `Time.hpp` might trigger other include-related problems down the road... Well this is what master is for? Doing a `autoproj rebuild` in my current Project succeeds. There is no "base/samples" counterpart for Temperature yet, which might use `Time.hpp`.
