### PR TITLE
Casting of numeric types in base::Time::toTimeval()

### DIFF
--- a/base/Time.hpp
+++ b/base/Time.hpp
@@ -65,7 +65,7 @@ namespace base
         /** Converts this time as a timeval object */
         timeval toTimeval() const
         {
-            timeval tv = { microseconds / UsecPerSec, microseconds % UsecPerSec };
+            timeval tv = { static_cast<__time_t>(microseconds / UsecPerSec), static_cast<__suseconds_t>(microseconds % UsecPerSec) };
             return tv;
         }
 


### PR DESCRIPTION
I got the following error when compiling image_processing/stereo:

```
In file included from /media/data/Development/SpaceBotNew/install/include/base/samples/Frame.hpp:18:0,
                 from /media/data/Development/SpaceBotNew/install/include/frame_helper/Calibration.h:7,
                 from /media/data/Development/SpaceBotNew/install/include/frame_helper/CalibrationCv.h:6,
                 from /media/data/Development/SpaceBotNew/image_processing/stereo/src/densestereo.h:8,
                 from /media/data/Development/SpaceBotNew/image_processing/stereo/src/densestereo.cpp:1:
/media/data/Development/SpaceBotNew/install/include/base/Time.hpp: In member function ‘timeval base::Time::toTimeval() const’:
/media/data/Development/SpaceBotNew/install/include/base/Time.hpp:68:81: error: narrowing conversion of ‘(((long long int)((const base::Time*)this)->base::Time::microseconds) / 1000000ll)’ from ‘long long int’ to ‘__time_t {aka long int}’ inside { } [-fpermissive]
/media/data/Development/SpaceBotNew/install/include/base/Time.hpp:68:81: error: narrowing conversion of ‘(((long long int)((const base::Time*)this)->base::Time::microseconds) % 1000000ll)’ from ‘long long int’ to ‘__suseconds_t {aka long int}’ inside { } [-fpermissive]
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-unused-local-typedefs" [enabled by default]
make[2]: *** [src/CMakeFiles/stereo.dir/densestereo.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/stereo.dir/all] Error 2
make: *** [all] Error 2
```

It works with the patch.
