### PR TITLE
add default constructor to base::samples::Pressure

### DIFF
--- a/base/samples/Pressure.hpp
+++ b/base/samples/Pressure.hpp
@@ -3,6 +3,7 @@
 
 #include <base/Pressure.hpp>
 #include <base/Time.hpp>
+#include <base/Float.hpp>
 
 namespace base
 {
@@ -13,6 +14,9 @@ namespace base
         {
             /** The sample timestamp */
             base::Time time;
+
+            Pressure()
+                : base::Pressure(base::Pressure::fromPascal(base::unknown<float>())) {}
 
             Pressure(base::Time const& time, base::Pressure pressure)
                 : base::Pressure(pressure)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -843,4 +843,11 @@ BOOST_AUTO_TEST_CASE( trajectory )
     tr.speed = -5;    
     BOOST_CHECK(!tr.driveForward());
 }
+
+BOOST_AUTO_TEST_CASE( pressure )
+{
+    base::Pressure pressure;
+    base::samples::Pressure pressureSample;
+}
+
 #endif 


### PR DESCRIPTION
This is required to use it as an interface type
