### PR TITLE
Initialize Angle, Pressure and Temperature with base::unknown in default constructor

### DIFF
--- a/base/Angle.hpp
+++ b/base/Angle.hpp
@@ -6,6 +6,7 @@
 #include <base/Eigen.hpp>
 #include <iostream>
 #include <base/Deprecated.hpp>
+#include <base/Float.hpp>
 
 namespace base
 {
@@ -28,9 +29,9 @@ public:
     double rad;
 
     /** 
-     * default constructor, which will leave the angle uninitialized.
+     * default constructor, which will initialize the value to unknown (NaN)
      */
-    Angle() {}
+    Angle() : rad(base::unknown<double>()) {}
     
 protected:
     explicit Angle( double rad ) : rad(rad) 

--- a/base/Pressure.hpp
+++ b/base/Pressure.hpp
@@ -1,6 +1,8 @@
 #ifndef __BASE_PRESSURE_HPP__
 #define __BASE_PRESSURE_HPP__
 
+#include<base/Float.hpp>
+
 namespace base
 {
     /** Representation of a pressure value
@@ -19,6 +21,11 @@ namespace base
          * the initializers / accessors
          */
         float pascal;
+
+        /** 
+         * default constructor, which will initialize the value to unknown (NaN)
+         */
+        Pressure() : pascal(base::unknown<float>()) {}
 
     public:
         /** Create a pressure object using a value in pascals */

--- a/base/Temperature.hpp
+++ b/base/Temperature.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/format.hpp>
 #include <complex>      // std::abs
+#include <base/Float.hpp>
 
 namespace base
 {
@@ -28,7 +29,7 @@ public:
     /** 
      * default constructor, which will leave the temperature uninitialized.
      */
-    Temperature() {}
+    Temperature() : kelvin(base::unknown<double>()) {}
     
 protected:
     explicit Temperature( double kelvin ) : kelvin(kelvin) 


### PR DESCRIPTION
This is to prevent accidental use of uninitialized values.