### PR TITLE
Fix shadow warnings

### DIFF
--- a/base/Angle.hpp
+++ b/base/Angle.hpp
@@ -264,7 +264,7 @@ public:
     {
     }
 
-    AngleSegment(const Angle &start, double width): width(width), startRad(start.getRad()), endRad(startRad + width)
+    AngleSegment(const Angle &start, double _width): width(_width), startRad(start.getRad()), endRad(startRad + width)
     {
         if(width < 0)
             throw std::runtime_error("Error got segment with negative width");

--- a/base/Angle.hpp
+++ b/base/Angle.hpp
@@ -33,7 +33,7 @@ public:
     Angle() {}
     
 protected:
-    explicit Angle( double rad ) : rad(rad) 
+    explicit Angle( double _rad ) : rad(_rad)
     { 
 	canonize(); 
     }

--- a/base/Pose.hpp
+++ b/base/Pose.hpp
@@ -78,8 +78,8 @@ namespace base
 	/** 
 	 * constructor with distance and angle thresholds
 	 */
-	PoseUpdateThreshold( double distance, double angle )
-	    : distance( distance ), angle( angle ) {};
+	PoseUpdateThreshold( double _distance, double _angle )
+	    : distance( _distance ), angle( _angle ) {};
 
 	/** 
 	 * test if distance or angle is greater than the 

--- a/base/Pose.hpp
+++ b/base/Pose.hpp
@@ -85,9 +85,9 @@ namespace base
 	 * test if distance or angle is greater than the 
 	 * stored threshold.
 	 */
-	bool test( double distance, double angle )
+	bool test( double otherDistance, double otherAngle )
 	{
-	    return distance > this->distance || angle > this->angle;
+	    return otherDistance > distance || otherAngle > angle;
 	}
 
 	/** 

--- a/base/Time.hpp
+++ b/base/Time.hpp
@@ -185,7 +185,6 @@ namespace base
             if(resolution > Seconds)
             {
                 size_t pos = stringTime.find_last_of(':');
-                std::string mainTime = stringTime.substr(0,pos-1);
                 std::string usecsString = stringTime.substr(pos+1);
                 size_t usecsStringLength = usecsString.size();
                 if( (usecsStringLength == 3 || usecsStringLength == 6) && !(usecsStringLength == 3 && resolution > Milliseconds))

--- a/base/Time.hpp
+++ b/base/Time.hpp
@@ -17,8 +17,8 @@ namespace base
     struct Time
     {
     private:
-        explicit Time(int64_t microseconds)
-            : microseconds(microseconds) { }
+        explicit Time(int64_t _microseconds)
+            : microseconds(_microseconds) { }
     public:
         int64_t microseconds;
 

--- a/base/Waypoint.hpp
+++ b/base/Waypoint.hpp
@@ -19,16 +19,21 @@ namespace base
         double tol_position;
         //tollerance of the heading in rad
         double tol_heading;
-      
 
+        // default: initializing with identity and zero
         Waypoint()
-	  : position(Position::Identity()), heading(0), tol_position(0), tol_heading(0)  {}
-      
-	Waypoint(base::Vector3d const& position, double heading, double tol_position, double tol_heading):
-	    position(position), heading(heading), tol_position(tol_position), tol_heading(tol_heading) {};
-	Waypoint(Eigen::Vector3d const& position, double heading, double tol_position, double tol_heading):
-	    position(position), heading(heading), tol_position(tol_position), tol_heading(tol_heading) {};
-
+            : position(Position::Identity()), heading(0), tol_position(0),
+              tol_heading(0){}
+        // use base::Vector3d
+        Waypoint(base::Vector3d const &_position, double _heading,
+                 double _tol_position, double _tol_heading)
+            : position(_position), heading(_heading),
+              tol_position(_tol_position), tol_heading(_tol_heading){}
+        // convenience: same for Eigen::Vector3d
+        Waypoint(Eigen::Vector3d const &_position, double _heading,
+                 double _tol_position, double _tol_heading)
+            : position(_position), heading(_heading),
+              tol_position(_tol_position), tol_heading(_tol_heading){}
     };
 }
 

--- a/base/samples/Frame.hpp
+++ b/base/samples/Frame.hpp
@@ -401,7 +401,8 @@ namespace base { namespace samples { namespace frame {
                 }
             }
 	    inline void setImage(const std::vector<uint8_t> &newImage) {
-                return setImage(&newImage[0], newImage.size());
+                // calling the overloading function wich uses the "char*" interface
+                return setImage(newImage.data(), newImage.size());
 	    }
             /** This is for backward compatibility for the people that were
              * using the 'char' signature */
@@ -415,10 +416,10 @@ namespace base { namespace samples { namespace frame {
 	    }
 
 	    inline uint8_t *getImagePtr() {
-		return static_cast<uint8_t *>(&this->image[0]);
+		return static_cast<uint8_t *>(image.data());
 	    }
 	    inline const uint8_t *getImageConstPtr() const {
-		return static_cast<const uint8_t *>(&this->image[0]);
+		return static_cast<const uint8_t *>(image.data());
 	    }
 
             inline uint8_t* getLastByte(){

--- a/base/samples/Frame.hpp
+++ b/base/samples/Frame.hpp
@@ -94,9 +94,9 @@ namespace base { namespace samples { namespace frame {
 	    }
 	    
             //@depth number of bits per pixel and channel
-	    Frame(uint16_t width, uint16_t height, uint8_t depth=8, frame_mode_t mode=MODE_GRAYSCALE, uint8_t const val = 0,size_t size=0)
+	    Frame(uint16_t width, uint16_t height, uint8_t depth=8, frame_mode_t mode=MODE_GRAYSCALE, uint8_t const val = 0,size_t sizeInBytes=0)
 	    {
-		init(width,height,depth,mode,val,size);
+		init(width,height,depth,mode,val,sizeInBytes);
 	    }
 
 	    //makes a copy of other
@@ -127,11 +127,11 @@ namespace base { namespace samples { namespace frame {
 	       copyImageIndependantAttributes(other);
 	    }
 
-	    void init(uint16_t width, uint16_t height, uint8_t depth=8, frame_mode_t mode=MODE_GRAYSCALE, const uint8_t val = 0,size_t size=0)
+	    void init(uint16_t width, uint16_t height, uint8_t depth=8, frame_mode_t mode=MODE_GRAYSCALE, const uint8_t val = 0, size_t sizeInBytes=0)
 	    {
                //change size if the frame does not fit
 	       if(this->size.height != height || this->size.width !=  width || this->frame_mode != mode || 
-                 this->data_depth != depth || (size != 0 && size != image.size()))
+                 this->data_depth != depth || (sizeInBytes != 0 && sizeInBytes != image.size()))
                {
                 //check if depth = 0
                 //this might be a programmer error 
@@ -143,11 +143,11 @@ namespace base { namespace samples { namespace frame {
 		setDataDepth(depth);
                }
                //calculate size if not given 
-               if(!size)
-                   size = getPixelSize() * getPixelCount();
+               if(!sizeInBytes)
+                  sizeInBytes = getPixelSize() * getPixelCount();
 
-               validateImageSize(size);
-               image.resize(size);
+               validateImageSize(sizeInBytes);
+               image.resize(sizeInBytes);
 	       reset(val);
 	    }
 
@@ -389,29 +389,29 @@ namespace base { namespace samples { namespace frame {
 		return this->image;
 	    }
 
-            void validateImageSize(uint32_t size) const {
-                uint32_t expected_size = getPixelSize()*getPixelCount();
-                if (!isCompressed() && size != expected_size){
+            void validateImageSize(size_t sizeToValidate) const {
+                size_t expected_size = getPixelSize()*getPixelCount();
+                if (!isCompressed() && sizeToValidate != expected_size){
 		    std::cerr << "Frame: "
 		              << __FUNCTION__ << " (" << __FILE__ << ", line "
 		              << __LINE__ << "): " << "image size mismatch in setImage() ("
-		              << "getting " << size << " bytes but I was expecting " << expected_size << " bytes)"
+		              << "getting " << sizeToValidate << " bytes but I was expecting " << expected_size << " bytes)"
 		              << std::endl;
                     throw std::runtime_error("Frame::validateImageSize: wrong image size!");
                 }
             }
-	    inline void setImage(const std::vector<uint8_t> &image) {
-                return setImage(&image[0], image.size());
+	    inline void setImage(const std::vector<uint8_t> &newImage) {
+                return setImage(&newImage[0], newImage.size());
 	    }
             /** This is for backward compatibility for the people that were
              * using the 'char' signature */
-	    inline void setImage(const char *data, uint32_t size) {
-                return setImage(reinterpret_cast<const uint8_t*>(data), size);
+	    inline void setImage(const char *data, size_t newImageSize) {
+                return setImage(reinterpret_cast<const uint8_t*>(data), newImageSize);
             }
-	    inline void setImage(const uint8_t *data, uint32_t size) {
-                validateImageSize(size);
-                image.resize(size);
-		memcpy(&this->image[0], data, size);
+	    inline void setImage(const uint8_t *data, size_t newImageSize) {
+                validateImageSize(newImageSize);
+                image.resize(newImageSize);
+		memcpy(&this->image[0], data, newImageSize);
 	    }
 
 	    inline uint8_t *getImagePtr() {

--- a/base/samples/RigidBodyState.hpp
+++ b/base/samples/RigidBodyState.hpp
@@ -272,22 +272,22 @@ namespace base { namespace samples {
         void invalidateAngularVelocity() { angular_velocity = invalidValue(); }
         void invalidateAngularVelocityCovariance() { cov_angular_velocity = invalidCovariance(); }
 
-        void invalidateValues ( bool position, bool orientation, bool velocity = true, bool angular_velocity = true ) {
-            if ( position ) invalidatePosition();
-            if ( orientation ) invalidateOrientation();
-            if ( velocity ) invalidateVelocity();
-            if ( angular_velocity ) invalidateAngularVelocity();
-        }
-        
-        void invalidateCovariances ( bool position = true, bool orientation = true, bool velocity = true, bool angular_velocity = true ) {
-            if ( position ) invalidatePositionCovariance();
-            if ( orientation ) invalidateOrientationCovariance();
-            if ( velocity ) invalidateVelocityCovariance();
-            if ( angular_velocity ) invalidateAngularVelocityCovariance();
+        void invalidateValues(bool invPos, bool invOri, bool invVel = true,
+                              bool invAngVel = true) {
+            if (invPos) invalidatePosition();
+            if (invOri) invalidateOrientation();
+            if (invVel) invalidateVelocity();
+            if (invAngVel) invalidateAngularVelocity();
         }
 
+        void invalidateCovariances(bool invPos = true, bool invOri = true,
+                                   bool invVel = true, bool invAngVel = true) {
+            if (invPos) invalidatePositionCovariance();
+            if (invOri) invalidateOrientationCovariance();
+            if (invVel) invalidateVelocityCovariance();
+            if (invAngVel) invalidateAngularVelocityCovariance();
+        }
     };
 }}
 
 #endif
-


### PR DESCRIPTION
Some simple fixes which accumulated while playing around. The most controversial would be dcc0bb005e1ca20253c437dd16709327eb60d339

In 61b4abdefcfe24c6e39277789bfef46a7797d0a3 the default constructor still does zero-initialization -- instead of NaN as discussed on the ML.