### PR TITLE
add support to move a loaded model w.r.t the reference RBS

### DIFF
--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -16,10 +16,15 @@ RigidBodyStateVisualization::RigidBodyStateVisualization(QObject* parent)
     , color(1, 1, 1)
     , total_size(1)
     , main_size(0.1)
+    , translation(0, 0, 0)
+    , rotation(0, 0, 0, 1)
     , body_type(BODY_NONE)
     , forcePositionDisplay(false)
     , forceOrientationDisplay(false)
 {
+    state = base::samples::RigidBodyState::invalid();
+    state.position = base::Vector3d::Zero();
+    state.orientation = base::Quaterniond::Identity();
 }
 
 RigidBodyStateVisualization::~RigidBodyStateVisualization()
@@ -195,6 +200,22 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
     setDirty();
 }
 
+QVector3D RigidBodyStateVisualization::getTranslation() const
+{
+    return QVector3D(translation.x(), translation.y(), translation.z());
+}
+void RigidBodyStateVisualization::setTranslation(QVector3D const& v)
+{
+    translation = osg::Vec3(v.x(), v.y(), v.z());
+    setDirty();
+}
+
+void RigidBodyStateVisualization::setRotation(QQuaternion const& q)
+{
+    rotation = osg::Quat(q.x(), q.y(), q.z(), q.scalar());
+    setDirty();
+}
+
 void RigidBodyStateVisualization::displayCovariance(bool enable)
 { covariance = enable; }
 bool RigidBodyStateVisualization::isCovarianceDisplayed() const
@@ -250,8 +271,10 @@ void RigidBodyStateVisualization::updateMainNode(osg::Node* node)
 
     if (forcePositionDisplay || state.hasValidPosition())
     {
-        pos.set(state.position.x(), state.position.y(), state.position.z());
-        body_pose->setPosition(pos);
+	osg::Vec3d pos(
+                state.position.x(), state.position.y(), state.position.z());
+        
+        body_pose->setPosition(pos + translation);
     }
     if (needs_uncertainty)
     {
@@ -265,11 +288,11 @@ void RigidBodyStateVisualization::updateMainNode(osg::Node* node)
     }
     if (forceOrientationDisplay || state.hasValidOrientation())
     {
-        orientation.set(state.orientation.x(),
+	osg::Quat orientation(state.orientation.x(),
                 state.orientation.y(),
                 state.orientation.z(),
                 state.orientation.w());
-        body_pose->setAttitude(orientation);
+        body_pose->setAttitude(rotation * orientation);
     }
 }
 

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -81,6 +81,10 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 	
 	void setColor(const osg::Vec4d& color, osg::Geode* geode);
 	
+        QVector3D getTranslation() const;
+        void setTranslation(QVector3D const& v);
+        void setRotation(QQuaternion const& q);
+
     private:
         bool covariance;
         bool covariance_with_samples;
@@ -88,11 +92,12 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         double total_size;
         double main_size;
 
+        osg::Vec3 translation;
+        osg::Quat rotation;
+
         enum BODY_TYPES
         { BODY_NONE, BODY_SIMPLE, BODY_SPHERE, BODY_CUSTOM_MODEL };
 
-	osg::Vec3d pos;
-	osg::Quat orientation;
         BODY_TYPES body_type;
 	osg::ref_ptr<osg::Node>  body_model;
         osg::ref_ptr<osg::Group> createSimpleBody(double size);


### PR DESCRIPTION
When using loadModel, it is possible that the rigidbodystate being visualized is not the same than the model's reference frame. Instead of requiring a modification to the model, allow to specify the translation and rotation between the two.