### PR TITLE
Viz add texturing support to rbs visualization

### DIFF
--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -5,9 +5,9 @@
 #include <osg/PositionAttitudeTransform>
 #include <osgDB/ReadFile>
 #include <osg/Material>
+#include <osgFX/BumpMapping>
 
 using namespace osg;
-
 namespace vizkit3d 
 {
 
@@ -19,6 +19,8 @@ RigidBodyStateVisualization::RigidBodyStateVisualization(QObject* parent)
     , total_size(1)
     , main_size(0.1)
     , body_type(BODY_NONE)
+    , texture_dirty(false)
+    , bump_mapping_dirty(false)
     , forcePositionDisplay(false)
     , forceOrientationDisplay(false)
 {
@@ -49,7 +51,101 @@ bool RigidBodyStateVisualization::isOrientationDisplayForced() const
 void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
 { forceOrientationDisplay = flag; }
 
-ref_ptr<osg::Group> RigidBodyStateVisualization::createSimpleSphere(double size)
+void RigidBodyStateVisualization::setTexture(QString const& path)
+{ return setTexture(path.toStdString()); }
+void RigidBodyStateVisualization::setTexture(std::string const& path)
+{
+    if (path.empty())
+        return clearTexture();
+
+    image = osgDB::readImageFile(path);
+    texture_dirty = true;
+}
+
+void RigidBodyStateVisualization::clearTexture()
+{
+    image.release();
+    texture_dirty = true;
+}
+
+void RigidBodyStateVisualization::addBumpMapping(
+                QString const& diffuse_color_map_path,
+                QString const& normal_map_path)
+{ return addBumpMapping(diffuse_color_map_path.toStdString(),
+        normal_map_path.toStdString()); }
+void RigidBodyStateVisualization::addBumpMapping(
+                std::string const& diffuse_color_map_path,
+                std::string const& normal_map_path)
+{
+    if (!body_model->asGeode())
+    {
+        std::cerr << "model is not a geometry, cannot use bump mapping" << std::endl;
+        return;
+    }
+
+    // Setup the textures
+    diffuse_image = osgDB::readImageFile(diffuse_color_map_path);
+    normal_image  = osgDB::readImageFile(normal_map_path);
+
+    // And add bump mapping
+    osgFX::BumpMapping* bump_mapping = new osgFX::BumpMapping();
+    bump_mapping->setLightNumber(0);
+    bump_mapping->setNormalMapTextureUnit(1);
+    bump_mapping->setDiffuseTextureUnit(2);
+    this->bump_mapping = bump_mapping;
+    bump_mapping_dirty = true;
+}
+
+void RigidBodyStateVisualization::updateTexture()
+{
+    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
+    if (!image)
+    {
+        state->setTextureMode(0, GL_TEXTURE_2D, StateAttribute::OFF);
+        return;
+    }
+    else
+    {
+        texture->setImage(image.get());
+        state->setTextureAttributeAndModes(0, texture, StateAttribute::ON);
+    }
+}
+
+void RigidBodyStateVisualization::updateBumpMapping()
+{
+    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
+
+    if (!bump_mapping)
+    {
+        diffuse_image.release();
+        normal_image.release();
+        state->setTextureMode(1, GL_TEXTURE_2D, StateAttribute::OFF);
+        state->setTextureMode(2, GL_TEXTURE_2D, StateAttribute::OFF);
+        return;
+    }
+    else
+    {
+
+        ref_ptr<Geometry> geometry = body_model->asGeode()->getDrawable(0)->asGeometry();
+        ref_ptr<Array> tex_coord = geometry->getTexCoordArray(0);
+        geometry->setTexCoordArray(1, tex_coord);
+        geometry->setTexCoordArray(2, tex_coord);
+
+        diffuse_texture->setImage(diffuse_image.get());
+        normal_texture->setImage(normal_image.get());
+        state->setTextureAttributeAndModes(1, normal_texture, StateAttribute::ON);
+        state->setTextureAttributeAndModes(2, diffuse_texture, StateAttribute::ON);
+        bump_mapping->prepareChildren();
+    }
+}
+
+void RigidBodyStateVisualization::removeBumpMapping()
+{
+    bump_mapping.release();
+    bump_mapping_dirty = true;
+}
+
+ref_ptr<Group> RigidBodyStateVisualization::createSimpleSphere(double size)
 {   
     ref_ptr<Group> group = new Group();
     
@@ -174,6 +270,13 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
     ref_ptr<Node> model = osgDB::readNodeFile(path);
     body_type  = BODY_CUSTOM_MODEL;
     body_model = model;
+    if (!body_model->asGeode())
+        std::cerr << "model is not a geode, using bump mapping will not be possible" << std::endl;
+    else if (!body_model->asGeode()->getDrawable(0))
+        std::cerr << "model does not contain a mesh, using bump mapping will not be possible" << std::endl;
+    else if (!body_model->asGeode()->getDrawable(0)->asGeometry())
+        std::cerr << "model does not contain a mesh, using bump mapping will not be possible" << std::endl;
+
     model_path = QString::fromStdString(path);
     //set plugin name
     if(vizkit3d_plugin_name.isEmpty())
@@ -220,6 +323,23 @@ ref_ptr<Node> RigidBodyStateVisualization::createMainNode()
         resetModel(total_size);
     body_pose->addChild(body_model);
     group->addChild(body_pose);
+
+    texture = new osg::Texture2D;
+    texture->setWrap(Texture::WRAP_S, Texture::REPEAT);
+    texture->setWrap(Texture::WRAP_T, Texture::REPEAT);
+    texture->setFilter(osg::Texture::MIN_FILTER, osg::Texture::LINEAR_MIPMAP_LINEAR);
+    texture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::LINEAR);
+    diffuse_texture = new osg::Texture2D;
+    diffuse_texture->setWrap(Texture::WRAP_S, Texture::REPEAT);
+    diffuse_texture->setWrap(Texture::WRAP_T, Texture::REPEAT);
+    diffuse_texture->setFilter(osg::Texture::MIN_FILTER, osg::Texture::LINEAR_MIPMAP_LINEAR);
+    diffuse_texture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::LINEAR);
+    normal_texture = new osg::Texture2D;
+    normal_texture->setWrap(Texture::WRAP_S, Texture::REPEAT);
+    normal_texture->setWrap(Texture::WRAP_T, Texture::REPEAT);
+    normal_texture->setFilter(osg::Texture::MIN_FILTER, osg::Texture::LINEAR_MIPMAP_LINEAR);
+    normal_texture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::LINEAR);
+
     return group;
 }
 
@@ -247,9 +367,19 @@ void RigidBodyStateVisualization::updateMainNode(Node* node)
     }
 
     // Reset the body model if needed
-    osg::Node* body_node = body_pose->getChild(0);
-    if (body_node != this->body_model)
-        body_pose->setChild(0, this->body_model);
+    Node* body_node = body_pose->getChild(0);
+    if (bump_mapping && body_node != bump_mapping)
+    {
+        bump_mapping->addChild(body_model);
+        body_pose->setChild(0, bump_mapping);
+    }
+    else if (body_node != body_model)
+        body_pose->setChild(0, body_model);
+
+    if (texture_dirty)
+        updateTexture();
+    if (bump_mapping_dirty)
+        updateBumpMapping();
 
     if (forcePositionDisplay || state.hasValidPosition())
     {

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -100,6 +100,10 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
                 std::string const& normal_map_path);
         void removeBumpMapping();
 
+        QVector3D getTranslation() const;
+        void setTranslation(QVector3D const& v);
+        void setRotation(QQuaternion const& q);
+
     private:
         bool covariance;
         bool covariance_with_samples;
@@ -107,11 +111,12 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         double total_size;
         double main_size;
 
+        osg::Vec3 translation;
+        osg::Quat rotation;
+
         enum BODY_TYPES
         { BODY_NONE, BODY_SIMPLE, BODY_SPHERE, BODY_CUSTOM_MODEL };
 
-	osg::Vec3d pos;
-	osg::Quat orientation;
         BODY_TYPES body_type;
 	osg::ref_ptr<osg::Node>  body_model;
         osg::ref_ptr<osg::Group> createSimpleBody(double size);

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -5,6 +5,14 @@
 #include <Eigen/Geometry>
 #include <base/samples/RigidBodyState.hpp>
 
+#include <osg/Image>
+#include <osg/Texture2D>
+
+namespace osgFX
+{
+    class BumpMapping;
+}
+
 namespace vizkit3d 
 {
 
@@ -81,6 +89,17 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 	
 	void setColor(const osg::Vec4d& color, osg::Geode* geode);
 	
+        void setTexture(QString const& path);
+        void setTexture(std::string const& path);
+        void clearTexture();
+        void addBumpMapping(
+                QString const& diffuse_color_map_path,
+                QString const& normal_map_path);
+        void addBumpMapping(
+                std::string const& diffuse_color_map_path,
+                std::string const& normal_map_path);
+        void removeBumpMapping();
+
     private:
         bool covariance;
         bool covariance_with_samples;
@@ -97,6 +116,19 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 	osg::ref_ptr<osg::Node>  body_model;
         osg::ref_ptr<osg::Group> createSimpleBody(double size);
 	osg::ref_ptr<osg::Group> createSimpleSphere(double size);
+
+        osg::ref_ptr<osg::Image> image;
+        osg::ref_ptr<osg::Texture2D> texture;
+        bool texture_dirty;
+        void updateTexture();
+
+        osg::ref_ptr<osg::Image> diffuse_image;
+        osg::ref_ptr<osg::Image> normal_image;
+        osg::ref_ptr<osg::Texture2D> diffuse_texture;
+        osg::ref_ptr<osg::Texture2D> normal_texture;
+        osg::ref_ptr<osgFX::BumpMapping> bump_mapping;
+        bool bump_mapping_dirty;
+        void updateBumpMapping();
 
         bool forcePositionDisplay;
         bool forceOrientationDisplay;


### PR DESCRIPTION
This adds texturing and bump-mapping support to the RBS visualizer. Since the visualizer already supports loading models, I felt it was the best place right now.