### PR TITLE
Trajectory visualization: use a method instead of a block as callback

### DIFF
--- a/viz/TrajectoryVisualization.hpp
+++ b/viz/TrajectoryVisualization.hpp
@@ -6,6 +6,7 @@
 #include <vizkit3d/Vizkit3DPlugin.hpp>
 #include <base/geometry/Spline.hpp>
 #include <base/Trajectory.hpp>
+#include <base/samples/RigidBodyState.hpp>
 
 namespace vizkit3d 
 {
@@ -40,6 +41,8 @@ class TrajectoryVisualization: public Vizkit3DPlugin<base::Vector3d>
         { Vizkit3DPlugin<base::Vector3d>::updateData(data); }
         Q_INVOKABLE void updateTrajectory(const base::Vector3d& data)
         { updateData(data); }
+        Q_INVOKABLE void updateTrajectory(const base::samples::RigidBodyState& data)
+        { updateData(data.position); }
 
     public slots:
         int getMaxNumberOfPoints(){return max_number_of_points;};

--- a/viz/vizkit_plugin.rb
+++ b/viz/vizkit_plugin.rb
@@ -1,8 +1,6 @@
 Vizkit::UiLoader.register_3d_plugin('TrajectoryVisualization',"base", 'TrajectoryVisualization')
 Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "/base/Vector3d", :updateTrajectory)
-Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "/base/samples/RigidBodyState") do |obj,sample,_|
-    obj.updateTrajectory(sample.position)
-end
+Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "/base/samples/RigidBodyState", :updateTrajectory)
 Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "Eigen::Vector3", :updateTrajectory)
 Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "/base/geometry/Spline<3>", :updateSpline)
 Vizkit::UiLoader.register_3d_plugin_for('TrajectoryVisualization', "/wrappers/geometry/Spline", :updateSpline)


### PR DESCRIPTION
Using a block here currently leads to the problem that only the latest block is called with samples of both output ports, when attaching a second trajectory vizkit plugin to another output port.

There is apparently a problem of how the block callbacks are handled in vizkit.