### PR TITLE
Emit property changes

### DIFF
--- a/viz/LaserScanVisualization.cpp
+++ b/viz/LaserScanVisualization.cpp
@@ -151,7 +151,7 @@ osg::ref_ptr<osg::Node> LaserScanVisualization::cloneCurrentViz()
 }
 
 bool LaserScanVisualization::isYForwardModeEnabled() const { return mYForward; }
-void LaserScanVisualization::setYForwardMode(bool enabled) { mYForward = enabled; }
+void LaserScanVisualization::setYForwardMode(bool enabled) { mYForward = enabled; emit propertyChanged("YForward"); }
 
 void LaserScanVisualization::setColorize(bool value){colorize = value;emit propertyChanged("Colorize");}
 bool LaserScanVisualization::isColorizeEnabled()const { return colorize; }

--- a/viz/MotionCommandVisualization.cpp
+++ b/viz/MotionCommandVisualization.cpp
@@ -161,6 +161,7 @@ void MotionCommandVisualization::drawRotation()
 
 void MotionCommandVisualization::setFrontAxis(FrontAxis front_axis) {
     mFrontAxis = front_axis;
+    emit propertyChanged("frontAxis");
 }
 
 MotionCommandVisualization::FrontAxis MotionCommandVisualization::getFrontAxis() {

--- a/viz/PointcloudVisualization.cpp
+++ b/viz/PointcloudVisualization.cpp
@@ -64,6 +64,7 @@ void PointcloudVisualization::setPointSize(double size)
         osg::ref_ptr<osg::Point> pt = new osg::Point(size);
         pointGeom->getOrCreateStateSet()->setAttribute(pt, osg::StateAttribute::ON);
     }
+    emit propertyChanged("pointSize");
 }
 
 double PointcloudVisualization::getPointSize()

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -43,11 +43,11 @@ void RigidBodyStateVisualization::setColor(const Vec4d& color, Geode* geode)
 bool RigidBodyStateVisualization::isPositionDisplayForced() const
 { return forcePositionDisplay; }
 void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
-{ forcePositionDisplay = flag; }
+{ forcePositionDisplay = flag; emit propertyChanged("forcePositionDisplay"); }
 bool RigidBodyStateVisualization::isOrientationDisplayForced() const
 { return forceOrientationDisplay; }
 void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
-{ forceOrientationDisplay = flag; }
+{ forceOrientationDisplay = flag; emit propertyChanged("forceOrientationDisplay"); }
 
 ref_ptr<osg::Group> RigidBodyStateVisualization::createSimpleSphere(double size)
 {   
@@ -111,6 +111,7 @@ double RigidBodyStateVisualization::getMainSphereSize() const
 void RigidBodyStateVisualization::setMainSphereSize(double size)
 {
     main_size = size;
+    emit propertyChanged("sphereSize");
     // This triggers an update of the model if we don't have a custom model
     setSize(total_size);
 }
@@ -118,6 +119,7 @@ void RigidBodyStateVisualization::setMainSphereSize(double size)
 void RigidBodyStateVisualization::setSize(double size)
 {
     total_size = size;
+    emit propertyChanged("size");
     if (body_type == BODY_SIMPLE)
         resetModel(size);
     else if (body_type == BODY_SPHERE)
@@ -199,7 +201,7 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
 }
 
 void RigidBodyStateVisualization::displayCovariance(bool enable)
-{ covariance = enable; }
+{ covariance = enable; emit propertyChanged("displayCovariance"); }
 bool RigidBodyStateVisualization::isCovarianceDisplayed() const
 { return covariance; }
 
@@ -207,7 +209,7 @@ void RigidBodyStateVisualization::setColor(base::Vector3d const& color)
 { this->color = color; }
 
 void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
-{ covariance_with_samples = enable; }
+{ covariance_with_samples = enable; emit propertyChanged("displayCovarianceWithSamples"); }
 bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
 { return covariance_with_samples; }
 

--- a/viz/SonarGroundDistanceVisualization.hpp
+++ b/viz/SonarGroundDistanceVisualization.hpp
@@ -34,6 +34,7 @@ class SonarGroundDistanceVisualization : public Vizkit3DPlugin<base::samples::Ri
     public slots: 
         void setBeamWidth(double _beam_width){
             beam_width = _beam_width/180.0*M_PI;
+            emit propertyChanged("BeamWidth");
         }
         
         double getBeamWidth() const{

--- a/viz/TrajectoryVisualization.cpp
+++ b/viz/TrajectoryVisualization.cpp
@@ -55,6 +55,7 @@ void TrajectoryVisualization::setColor(double r, double g, double b, double a)
 void TrajectoryVisualization::setColor(const base::Vector3d& color)
 {
     setColor(color.x(), color.y(), color.z(), 1.0);
+    emit propertyChanged("Color");
 }
 
 
@@ -132,7 +133,7 @@ void TrajectoryVisualization::updateDataIntern( const base::Vector3d& data )
 void TrajectoryVisualization::setColor(QColor color)
 {
     setColor( color.redF(), color.greenF(), color.blueF(), color.alphaF() );
-    emit propertyChanged("color");
+    emit propertyChanged("Color");
 }
 
 QColor TrajectoryVisualization::getColor() const
@@ -157,6 +158,6 @@ void TrajectoryVisualization::setLineWidth(double line_width)
     stateset->setAttributeAndModes(linewidth,osg::StateAttribute::ON);
     stateset->setMode(GL_LIGHTING,osg::StateAttribute::OFF);
 
-    emit propertyChanged("line_width");
+    emit propertyChanged("LineWidth");
 }
 }

--- a/viz/TrajectoryVisualization.hpp
+++ b/viz/TrajectoryVisualization.hpp
@@ -43,7 +43,7 @@ class TrajectoryVisualization: public Vizkit3DPlugin<base::Vector3d>
 
     public slots:
         int getMaxNumberOfPoints(){return max_number_of_points;};
-        void setMaxNumberOfPoints(int points){max_number_of_points = points;};
+        void setMaxNumberOfPoints(int points){max_number_of_points = points; emit propertyChanged("MaxPoints");};
 	double getLineWidth();
 	void setLineWidth(double line_width);
         void setColor(QColor color);

--- a/viz/WaypointVisualization.cpp
+++ b/viz/WaypointVisualization.cpp
@@ -31,6 +31,7 @@ void WaypointVisualization::setColor(QColor q_color)
     color = osg::Vec4(q_color.redF(), q_color.greenF(), 
             q_color.blueF(), q_color.alphaF());
     setDirty();
+    emit propertyChanged("Color");
 }
 
 QColor WaypointVisualization::getColor() const


### PR DESCRIPTION
In many vizkit plugins of the base types property changes are not emited. Especially when changing a plugin property in ruby the property tree in die vizkit3d GUI is not updated, if the signal is not emited. 

This commit adds the signal emit to every property setter.