### PR TITLE
ruby: fix signed-ness of size-related methods in Eigenn bindings

### DIFF
--- a/bindings/ruby/ext/base_types_ruby/Eigen.cpp
+++ b/bindings/ruby/ext/base_types_ruby/Eigen.cpp
@@ -86,7 +86,7 @@ struct VectorX {
     VectorX* normalize() const { return new VectorX(v->normalized()); }
     void normalizeBang() const { v->normalize(); }
 
-    int size() { return v->size(); }
+    unsigned int size() { return v->size(); }
 
     double get(int i) const { return (*v)[i]; }
     void set(int i, double value) { (*v)[i] = value; }
@@ -131,9 +131,9 @@ struct MatrixX {
     
     double norm() const { return m->norm(); }
 
-    int rows() const { return m->rows(); }
-    int cols() const { return m->cols(); }
-    int size() const { return m->size(); }
+    unsigned int rows() const { return m->rows(); }
+    unsigned int cols() const { return m->cols(); }
+    unsigned int size() const { return m->size(); }
 
     double get(int i, int j ) const { return (*m)(i,j); }
     void set(int i, int j, double value) { (*m)(i,j) = value; }


### PR DESCRIPTION
The methods were returning a int instead a unsinged int. This fixes compiler warnings in base/orogen/std. The Eigen methods return unsigned ints already.