### PR TITLE
remove base/geometry/spline

### DIFF
--- a/bindings/ruby/lib/base/geometry/spline.rb
+++ b/bindings/ruby/lib/base/geometry/spline.rb
@@ -1,10 +1,6 @@
-require 'sisl/spline'
+puts "you cannot require 'base/geometry/spline' anymore"
+puts "It has been replaced by require 'sisl/spline' and"
+puts "  Base::Geometry::Spline is now SISL::Spline"
+puts "  Base::Geometry::Spline3 is now SISL::Spline3"
+raise LoadError, "use sisl/spline"
 
-module Types
-module Base
-    module Geometry
-        Spline = SISL::Spline
-        Spline3 = SISL::Spline3
-    end
-end
-end

--- a/bindings/ruby/lib/base/typelib/spline.rb
+++ b/bindings/ruby/lib/base/typelib/spline.rb
@@ -1,7 +1,7 @@
 
 ##
-# base/geometry/Spline to BaseTypes::Geometry::Spline convertions
-require 'base/geometry/spline'
+# base/geometry/Spline to SISL::Spline convertions
+require 'sisl/spline'
 Typelib.convert_to_ruby '/wrappers/geometry/Spline', SISL::Spline do |value|
     if value.dimension == 3
         result = SISL::Spline3.new(value.geometric_resolution, value.curve_order)

--- a/bindings/ruby/lib/base/typelib_plugin.rb
+++ b/bindings/ruby/lib/base/typelib_plugin.rb
@@ -1,4 +1,4 @@
-require 'base/geometry/spline'
+require 'sisl/spline'
 require 'base/typelib/joint_state'
 require 'base/typelib/time'
 require 'base/typelib/rigid_body_state'


### PR DESCRIPTION
It is incompatible with the new registry export mechanism in
Typelib's ruby bindings.