### PR TITLE
ruby: fix default value of wrappers/MatrixX

### DIFF
--- a/bindings/ruby/lib/base/typelib/eigen.rb
+++ b/bindings/ruby/lib/base/typelib/eigen.rb
@@ -17,6 +17,12 @@ Typelib.convert_from_ruby Eigen::Quaternion, '/wrappers/Quaternion</double>' do 
     t
 end
 
+Typelib.specialize '/wrappers/MatrixX</double>' do
+    def initialize
+        self.rows = self.cols = 0
+        super
+    end
+end
 Typelib.convert_to_ruby '/wrappers/MatrixX</double>', Eigen::MatrixX do |value|
     m = Eigen::MatrixX.new(value.rows,value.cols)
     m.from_a(value.data.to_a,value.rows,value.cols)


### PR DESCRIPTION
The randomly-initialized default value was not consistent w.r.t.
the size of the vector, and would sometimes lead to bad allocation
exceptions being thrown when converting to Eigen::MatrixX