### PR TITLE
DepthMap: added an additional single time field

### DIFF
--- a/base/samples/DepthMap.hpp
+++ b/base/samples/DepthMap.hpp
@@ -53,6 +53,13 @@ public:
 	UNIT_Y = 1,
 	UNIT_Z = 2
     };
+
+    /** Reference timestamp for the depth map sample.
+     * This timestamp is used for temporal alignment to other data samples
+     * and transformations. 
+     * It is important to always set here a meaningful value.
+     */
+    base::Time time;
     
     /** The timestamps can be either one timestamp for all measurements,
      * two for interpolation, per vertical entries, per horizontal entries


### PR DESCRIPTION
This time field is picked up by the stream aligner and transformer.
I noticed that this is missing for this type, when I was reviewing the new sonar type.

IMO the more cleaner option would be to inherit every type in samples from a timestamp interface, which implements a getTimestamp method the transformer could use.