### PR TITLE
Optionally show the source frame of a RigidBodyState

### DIFF
--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -6,6 +6,7 @@
 #include <osgDB/ReadFile>
 #include <osg/Material>
 #include <osgFX/BumpMapping>
+#include <osgText/Text>
 
 using namespace osg;
 namespace vizkit3d 
@@ -18,6 +19,7 @@ RigidBodyStateVisualization::RigidBodyStateVisualization(QObject* parent)
     , color(1, 1, 1)
     , total_size(1)
     , main_size(0.1)
+    , text_size(0.0)
     , translation(0, 0, 0)
     , rotation(0, 0, 0, 1)
     , body_type(BODY_NONE)
@@ -173,6 +175,16 @@ ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
     ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
     spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
     geode->addDrawable(spd);
+    if(text_size>0.0)
+    {
+        double actual_size = text_size * size;
+        ref_ptr<osgText::Text> text= new osgText::Text;
+        text->setText(state.sourceFrame);
+        text->setCharacterSize(actual_size);
+        text->setPosition(osg::Vec3d(actual_size/2,actual_size/2,0));
+        geode->addDrawable(text);
+    }
+
     group->addChild(geode);
     
     //up
@@ -213,6 +225,19 @@ void RigidBodyStateVisualization::setMainSphereSize(double size)
 {
     main_size = size;
     emit propertyChanged("sphereSize");
+    // This triggers an update of the model if we don't have a custom model
+    setSize(total_size);
+}
+
+double RigidBodyStateVisualization::getTextSize() const
+{
+    return text_size;
+}
+
+void RigidBodyStateVisualization::setTextSize(double size)
+{
+    text_size = size;
+    emit propertyChanged("textSize");
     // This triggers an update of the model if we don't have a custom model
     setSize(total_size);
 }

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -21,6 +21,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         Q_OBJECT
         Q_PROPERTY(double size READ getSize WRITE setSize)
         Q_PROPERTY(double sphereSize READ getMainSphereSize WRITE setMainSphereSize)
+        Q_PROPERTY(double textSize READ getTextSize WRITE setTextSize)
         Q_PROPERTY(bool displayCovariance READ isCovarianceDisplayed WRITE displayCovariance)
         Q_PROPERTY(bool displayCovarianceWithSamples READ isCovarianceDisplayedWithSamples WRITE displayCovarianceWithSamples)
         Q_PROPERTY(bool forcePositionDisplay READ isPositionDisplayForced WRITE setPositionDisplayForceFlag)
@@ -73,6 +74,13 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
          */
         double getMainSphereSize() const;
 
+        /** Sets the text size relative to the size of the complete object.
+         * If text size is positive, the name of the source frame is rendered in the visualization.
+         * The default is 0.0
+         */
+        void setTextSize(double size);
+        double getTextSize() const;
+
         void displayCovariance(bool enable);
         bool isCovarianceDisplayed() const;
         void displayCovarianceWithSamples(bool enable);
@@ -110,6 +118,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         base::Vector3d color;
         double total_size;
         double main_size;
+        double text_size;
 
         osg::Vec3 translation;
         osg::Quat rotation;


### PR DESCRIPTION
This is useful when visualizing multiple frames in the same visualization.
To activate this, setTextSize to a positive value.
Warning: If the name of the sourceFrame changes, the visualization is not automatically updated. You can reset the size to do so.