### PR TITLE
Visualize vector of RGBs

### DIFF
--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -51,15 +51,22 @@ void RigidBodyStateVisualization::setColor(const Vec4d& color, Geode* geode)
 
 bool RigidBodyStateVisualization::isPositionDisplayForced() const
 { return forcePositionDisplay; }
+
 void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
 { forcePositionDisplay = flag; emit propertyChanged("forcePositionDisplay"); }
+
 bool RigidBodyStateVisualization::isOrientationDisplayForced() const
 { return forceOrientationDisplay; }
+
 void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
-{ forceOrientationDisplay = flag; emit propertyChanged("forceOrientationDisplay"); }
+{ 
+    forceOrientationDisplay = flag; 
+    emit propertyChanged("forceOrientationDisplay"); 
+}
 
 void RigidBodyStateVisualization::setTexture(QString const& path)
 { return setTexture(path.toStdString()); }
+
 void RigidBodyStateVisualization::setTexture(std::string const& path)
 {
     if (path.empty())
@@ -78,8 +85,11 @@ void RigidBodyStateVisualization::clearTexture()
 void RigidBodyStateVisualization::addBumpMapping(
                 QString const& diffuse_color_map_path,
                 QString const& normal_map_path)
-{ return addBumpMapping(diffuse_color_map_path.toStdString(),
-        normal_map_path.toStdString()); }
+{
+    return addBumpMapping(diffuse_color_map_path.toStdString(), 
+            normal_map_path.toStdString()); 
+}
+        
 void RigidBodyStateVisualization::addBumpMapping(
                 std::string const& diffuse_color_map_path,
                 std::string const& normal_map_path)
@@ -175,7 +185,7 @@ ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
     ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
     spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
     geode->addDrawable(spd);
-    if(text_size>0.0)
+    if(text_size > 0.0)
     {
         double actual_size = text_size * size;
         ref_ptr<osgText::Text> text= new osgText::Text;
@@ -332,10 +342,12 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
     setDirty();
     emit propertyChanged("modelPath");
 }
+
 QVector3D RigidBodyStateVisualization::getTranslation() const
 {
     return QVector3D(translation.x(), translation.y(), translation.z());
 }
+
 void RigidBodyStateVisualization::setTranslation(QVector3D const& v)
 {
     translation = osg::Vec3(v.x(), v.y(), v.z());
@@ -350,6 +362,7 @@ void RigidBodyStateVisualization::setRotation(QQuaternion const& q)
 
 void RigidBodyStateVisualization::displayCovariance(bool enable)
 { covariance = enable; emit propertyChanged("displayCovariance"); }
+
 bool RigidBodyStateVisualization::isCovarianceDisplayed() const
 { return covariance; }
 
@@ -357,15 +370,18 @@ void RigidBodyStateVisualization::setColor(base::Vector3d const& color)
 { this->color = color; }
 
 void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
-{ covariance_with_samples = enable; emit propertyChanged("displayCovarianceWithSamples"); }
+{
+    covariance_with_samples = enable; 
+    emit propertyChanged("displayCovarianceWithSamples"); 
+}
+
 bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
 { return covariance_with_samples; }
 
 ref_ptr<Node> RigidBodyStateVisualization::createMainNode()
 {
     Group* group = new Group;
-    PositionAttitudeTransform* body_pose =
-        new PositionAttitudeTransform();
+    PositionAttitudeTransform* body_pose = new PositionAttitudeTransform();
     if (!body_model)
         resetModel(total_size);
     body_pose->addChild(body_model);
@@ -430,8 +446,7 @@ void RigidBodyStateVisualization::updateMainNode(Node* node)
 
     if (forcePositionDisplay || state.hasValidPosition())
     {
-	osg::Vec3d pos(
-                state.position.x(), state.position.y(), state.position.z());
+	    osg::Vec3d pos(state.position.x(), state.position.y(), state.position.z());
         
         body_pose->setPosition(pos + translation);
     }

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -13,6 +13,7 @@ using namespace osg;
 namespace vizkit3d 
 {
 
+// PUBLIC
 RigidBodyStateVisualization::RigidBodyStateVisualization(QObject* parent)
     : Vizkit3DPlugin<base::samples::RigidBodyState>(parent)
     , states()
@@ -37,356 +38,7 @@ RigidBodyStateVisualization::~RigidBodyStateVisualization()
 {
 }
 
-void RigidBodyStateVisualization::setColor(const Vec4d& color, Geode* geode)
-{
-    Material *material = new Material();
-    material->setDiffuse(Material::FRONT,  Vec4(0.1, 0.1, 0.1, 1.0));
-    material->setSpecular(Material::FRONT, Vec4(0.6, 0.6, 0.6, 1.0));
-    material->setAmbient(Material::FRONT,  Vec4(0.1, 0.1, 0.1, 1.0));
-    material->setEmission(Material::FRONT, color);
-    material->setShininess(Material::FRONT, 10.0);
-
-    geode->getOrCreateStateSet()->setAttribute(material);    
-}
-
-bool RigidBodyStateVisualization::isPositionDisplayForced() const
-{ return forcePositionDisplay; }
-
-void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
-{ forcePositionDisplay = flag; emit propertyChanged("forcePositionDisplay"); }
-
-bool RigidBodyStateVisualization::isOrientationDisplayForced() const
-{ return forceOrientationDisplay; }
-
-void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
-{ 
-    forceOrientationDisplay = flag; 
-    emit propertyChanged("forceOrientationDisplay"); 
-}
-
-void RigidBodyStateVisualization::setTexture(QString const& path)
-{ return setTexture(path.toStdString()); }
-
-void RigidBodyStateVisualization::setTexture(std::string const& path)
-{
-    if (path.empty())
-        return clearTexture();
-    
-    QString qt_path = createAbsolutePath(path);
-    
-    image = osgDB::readImageFile(qt_path.toStdString());
-    if(image == NULL) {
-        return;
-    }
-    texture_dirty = true;
-    texture_path = path;
-}
-
-QString RigidBodyStateVisualization::getTexture() const {
-    return QString(texture_path.c_str());
-}
-
-void RigidBodyStateVisualization::clearTexture()
-{
-    image.release();
-    texture_dirty = true;
-}
-
-void RigidBodyStateVisualization::addBumpMapping(
-                QString const& diffuse_color_map_path,
-                QString const& normal_map_path)
-{
-    return addBumpMapping(diffuse_color_map_path.toStdString(), 
-            normal_map_path.toStdString()); 
-}
-        
-void RigidBodyStateVisualization::addBumpMapping(
-                std::string const& diffuse_color_map_path,
-                std::string const& normal_map_path)
-{   
-    if(body_model == NULL) {
-        return;
-    }
-           
-    if (!body_model->asGeode()) {
-        std::cerr << "model is not a geode, cannot use bump mapping" << std::endl;
-        return;
-    } else if ( !body_model->asGeode()->getDrawable(0) || 
-                !body_model->asGeode()->getDrawable(0)->asGeometry()) {
-        std::cerr << "model does not contain a mesh, cannot use bump mapping" << std::endl;
-        return;
-    }
-
-    // Setup the textures
-    diffuse_image = osgDB::readImageFile(diffuse_color_map_path);
-    normal_image  = osgDB::readImageFile(normal_map_path);
-
-    // And add bump mapping
-    osgFX::BumpMapping* bump_mapping = new osgFX::BumpMapping();
-    bump_mapping->setLightNumber(0);
-    bump_mapping->setNormalMapTextureUnit(1);
-    bump_mapping->setDiffuseTextureUnit(2);
-    this->bump_mapping = bump_mapping;
-    bump_mapping_dirty = true;
-}
-
-void RigidBodyStateVisualization::updateTexture()
-{
-    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
-    if (!image)
-    {
-        state->setTextureMode(0, GL_TEXTURE_2D, StateAttribute::OFF);
-        return;
-    }
-    else
-    {
-        texture->setImage(image.get());
-        state->setTextureAttributeAndModes(0, texture, StateAttribute::ON);
-    }
-}
-
-void RigidBodyStateVisualization::updateBumpMapping()
-{
-    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
-
-    if (!bump_mapping)
-    {
-        diffuse_image.release();
-        normal_image.release();
-        state->setTextureMode(1, GL_TEXTURE_2D, StateAttribute::OFF);
-        state->setTextureMode(2, GL_TEXTURE_2D, StateAttribute::OFF);
-        return;
-    }
-    else
-    {
-        ref_ptr<Geometry> geometry = body_model->asGeode()->getDrawable(0)->asGeometry();
-        ref_ptr<Array> tex_coord = geometry->getTexCoordArray(0);
-        geometry->setTexCoordArray(1, tex_coord);
-        geometry->setTexCoordArray(2, tex_coord);
-
-        diffuse_texture->setImage(diffuse_image.get());
-        normal_texture->setImage(normal_image.get());
-        state->setTextureAttributeAndModes(1, normal_texture, StateAttribute::ON);
-        state->setTextureAttributeAndModes(2, diffuse_texture, StateAttribute::ON);
-        bump_mapping->prepareChildren();
-    }
-}
-
-void RigidBodyStateVisualization::removeBumpMapping()
-{
-    bump_mapping.release();
-    bump_mapping_dirty = true;
-}
-
-ref_ptr<Group> RigidBodyStateVisualization::createSimpleSphere(double size)
-{   
-    ref_ptr<Group> group = new Group();
-    
-    ref_ptr<Geode> geode = new Geode();
-    ref_ptr<Sphere> sp = new Sphere(Vec3f(0,0,0), main_size * size);
-    ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
-    spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
-    geode->addDrawable(spd);
-    group->addChild(geode);
-    
-    return group;
-}
-  
-ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
-{   
-    ref_ptr<Group> group = new Group();
-    
-    ref_ptr<Geode> geode = new Geode();
-    ref_ptr<Sphere> sp = new Sphere(Vec3f(0,0,0), main_size * size);
-    ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
-    spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
-    geode->addDrawable(spd);
-    group->addChild(geode);
-    
-    //up
-    ref_ptr<Geode> c1g = new Geode();
-    ref_ptr<Cylinder> c1 = new Cylinder(Vec3f(0, 0, size / 2), size / 40, size);
-    ref_ptr<ShapeDrawable> c1d = new ShapeDrawable(c1);
-    c1g->addDrawable(c1d);
-    setColor(Vec4f(0, 0, 1.0, 1.0), c1g);
-    group->addChild(c1g);
-    
-    //north direction
-    ref_ptr<Geode> c2g = new Geode();
-    ref_ptr<Cylinder> c2 = new Cylinder(Vec3f(0, size / 2, 0), size / 40, size);
-    c2->setRotation(Quat(M_PI/2.0, Vec3d(1,0,0)));
-    ref_ptr<ShapeDrawable> c2d = new ShapeDrawable(c2);
-    c2g->addDrawable(c2d);
-    setColor(Vec4f(0.0, 1.0, 0, 1.0), c2g);
-    group->addChild(c2g);
-
-    //east
-    ref_ptr<Geode> c3g = new Geode();
-    ref_ptr<Cylinder> c3 = new Cylinder(Vec3f(size / 2, 0, 0), size / 40, size);
-    c3->setRotation(Quat(M_PI/2.0, Vec3d(0,1,0)));
-    ref_ptr<ShapeDrawable> c3d = new ShapeDrawable(c3);
-    c3g->addDrawable(c3d);
-    setColor(Vec4f(1.0, 0.0, 0, 1.0), c3g);
-    group->addChild(c3g);
-
-    return group;
-}
-
-double RigidBodyStateVisualization::getMainSphereSize() const
-{
-    return main_size;
-}
-
-void RigidBodyStateVisualization::setMainSphereSize(double size)
-{
-    main_size = size;
-    emit propertyChanged("sphereSize");
-    // This triggers an update of the model if we don't have a custom model
-    setSize(total_size);
-}
-
-double RigidBodyStateVisualization::getTextSize() const
-{
-    return text_size;
-}
-
-void RigidBodyStateVisualization::setTextSize(double size)
-{
-    text_size = size;
-    emit propertyChanged("textSize");
-    // This triggers an update of the model if we don't have a custom model
-    setSize(total_size);
-}
-
-void RigidBodyStateVisualization::setSize(double size)
-{
-    total_size = size;
-    emit propertyChanged("size");
-    if (body_type == BODY_SIMPLE)
-        resetModel(size);
-    else if (body_type == BODY_SPHERE)
-        resetModelSphere(size);
-}
-
-double RigidBodyStateVisualization::getSize() const
-{
-    return total_size;
-}
-
-void RigidBodyStateVisualization::resetModel(double size)
-{
-    body_type  = BODY_SIMPLE;
-    body_model = createSimpleBody(size);
-    setDirty();
-}
-
-void RigidBodyStateVisualization::resetModelSphere(double size)
-{
-    body_type  = BODY_SPHERE;
-    body_model = createSimpleSphere(size);
-    setDirty();
-}
-
-QString RigidBodyStateVisualization::getModelPath() const
-{
-    if (body_type == BODY_SPHERE)
-        return "sphere";
-    else if (body_type == BODY_SIMPLE)
-        return "simple";
-    else
-        return model_path;
-}
-
-void RigidBodyStateVisualization::loadModel(QString const& path)
-{
-    return loadModel(path.toStdString());
-}
-
-void RigidBodyStateVisualization::loadModel(std::string const& path)
-{
-    if (path == "sphere")
-    {
-        resetModelSphere(total_size);
-        return;
-    }
-    else if (path == "simple")
-    {
-        resetModel(total_size);
-        return;
-    }
-
-    QString qt_path = createAbsolutePath(path);
-    
-    // If the model cannot be opened, NULL will be returned.
-    ref_ptr<Node> model = osgDB::readNodeFile(qt_path.toStdString());
-    if(model == NULL) {
-        return;
-    }
-    
-    body_type  = BODY_CUSTOM_MODEL;
-    body_model = model;
-    model_path = qt_path;
-    
-    // Set plugin name.
-    if(vizkit3d_plugin_name.isEmpty())
-    {
-        size_t found;
-        std::string str;
-        found = path.find_last_of("/\\");
-        if(found == std::string::npos)
-            str = path;
-        else
-            str = path.substr(found+1);
-            
-        found = str.find_last_of(".");
-        if(found != std::string::npos)
-        {
-            str = str.substr(0,found);
-            if(!str.empty()) {
-                setPluginName(QString::fromStdString(str));
-            }
-        }
-    }
-
-    setDirty();
-    emit propertyChanged("modelPath");
-}
-
-QVector3D RigidBodyStateVisualization::getTranslation() const
-{
-    return QVector3D(translation.x(), translation.y(), translation.z());
-}
-
-void RigidBodyStateVisualization::setTranslation(QVector3D const& v)
-{
-    translation = osg::Vec3(v.x(), v.y(), v.z());
-    setDirty();
-}
-
-void RigidBodyStateVisualization::setRotation(QQuaternion const& q)
-{
-    rotation = osg::Quat(q.x(), q.y(), q.z(), q.scalar());
-    setDirty();
-}
-
-void RigidBodyStateVisualization::displayCovariance(bool enable)
-{ covariance = enable; emit propertyChanged("displayCovariance"); }
-
-bool RigidBodyStateVisualization::isCovarianceDisplayed() const
-{ return covariance; }
-
-void RigidBodyStateVisualization::setColor(base::Vector3d const& color)
-{ this->color = color; }
-
-void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
-{
-    covariance_with_samples = enable; 
-    emit propertyChanged("displayCovarianceWithSamples"); 
-}
-
-bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
-{ return covariance_with_samples; }
-
+// PROTECTED
 ref_ptr<Node> RigidBodyStateVisualization::createMainNode()
 {
     Group* group = new Group;
@@ -500,6 +152,358 @@ void RigidBodyStateVisualization::updateDataIntern( const base::samples::RigidBo
 void RigidBodyStateVisualization::updateDataIntern( const std::vector<base::samples::RigidBodyState>& states )
 {
     this->states = states; 
+}
+
+// PUBLIC SLOTS
+bool RigidBodyStateVisualization::isPositionDisplayForced() const
+{ return forcePositionDisplay; }
+
+void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
+{ forcePositionDisplay = flag; emit propertyChanged("forcePositionDisplay"); }
+
+bool RigidBodyStateVisualization::isOrientationDisplayForced() const
+{ return forceOrientationDisplay; }
+
+void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
+{ 
+    forceOrientationDisplay = flag; 
+    emit propertyChanged("forceOrientationDisplay"); 
+}
+
+void RigidBodyStateVisualization::resetModel(double size)
+{
+    body_type  = BODY_SIMPLE;
+    body_model = createSimpleBody(size);
+    setDirty();
+}
+
+void RigidBodyStateVisualization::resetModelSphere(double size)
+{
+    body_type  = BODY_SPHERE;
+    body_model = createSimpleSphere(size);
+    setDirty();
+}
+
+QString RigidBodyStateVisualization::getModelPath() const
+{
+    if (body_type == BODY_SPHERE)
+        return "sphere";
+    else if (body_type == BODY_SIMPLE)
+        return "simple";
+    else
+        return model_path;
+}
+
+void RigidBodyStateVisualization::loadModel(QString const& path)
+{
+    return loadModel(path.toStdString());
+}
+
+void RigidBodyStateVisualization::loadModel(std::string const& path)
+{
+    if (path == "sphere")
+    {
+        resetModelSphere(total_size);
+        return;
+    }
+    else if (path == "simple")
+    {
+        resetModel(total_size);
+        return;
+    }
+
+    QString qt_path = createAbsolutePath(path);
+    
+    // If the model cannot be opened, NULL will be returned.
+    ref_ptr<Node> model = osgDB::readNodeFile(qt_path.toStdString());
+    if(model == NULL) {
+        return;
+    }
+    
+    body_type  = BODY_CUSTOM_MODEL;
+    body_model = model;
+    model_path = qt_path;
+    
+    // Set plugin name.
+    if(vizkit3d_plugin_name.isEmpty())
+    {
+        size_t found;
+        std::string str;
+        found = path.find_last_of("/\\");
+        if(found == std::string::npos)
+            str = path;
+        else
+            str = path.substr(found+1);
+            
+        found = str.find_last_of(".");
+        if(found != std::string::npos)
+        {
+            str = str.substr(0,found);
+            if(!str.empty()) {
+                setPluginName(QString::fromStdString(str));
+            }
+        }
+    }
+
+    setDirty();
+    emit propertyChanged("modelPath");
+}
+
+void RigidBodyStateVisualization::setMainSphereSize(double size)
+{
+    main_size = size;
+    emit propertyChanged("sphereSize");
+    // This triggers an update of the model if we don't have a custom model
+    setSize(total_size);
+}
+
+double RigidBodyStateVisualization::getMainSphereSize() const
+{
+    return main_size;
+}
+
+void RigidBodyStateVisualization::setSize(double size)
+{
+    total_size = size;
+    emit propertyChanged("size");
+    if (body_type == BODY_SIMPLE)
+        resetModel(size);
+    else if (body_type == BODY_SPHERE)
+        resetModelSphere(size);
+}
+
+double RigidBodyStateVisualization::getSize() const
+{
+    return total_size;
+}
+
+void RigidBodyStateVisualization::setTextSize(double size)
+{
+    text_size = size;
+    emit propertyChanged("textSize");
+    // This triggers an update of the model if we don't have a custom model
+    setSize(total_size);
+}
+
+double RigidBodyStateVisualization::getTextSize() const
+{
+    return text_size;
+}
+
+void RigidBodyStateVisualization::displayCovariance(bool enable)
+{ covariance = enable; emit propertyChanged("displayCovariance"); }
+
+bool RigidBodyStateVisualization::isCovarianceDisplayed() const
+{ return covariance; }
+
+void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
+{
+    covariance_with_samples = enable; 
+    emit propertyChanged("displayCovarianceWithSamples"); 
+}
+
+bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
+{ return covariance_with_samples; }
+
+void RigidBodyStateVisualization::setColor(base::Vector3d const& color)
+{ this->color = color; }
+
+void RigidBodyStateVisualization::setColor(const Vec4d& color, Geode* geode)
+{
+    Material *material = new Material();
+    material->setDiffuse(Material::FRONT,  Vec4(0.1, 0.1, 0.1, 1.0));
+    material->setSpecular(Material::FRONT, Vec4(0.6, 0.6, 0.6, 1.0));
+    material->setAmbient(Material::FRONT,  Vec4(0.1, 0.1, 0.1, 1.0));
+    material->setEmission(Material::FRONT, color);
+    material->setShininess(Material::FRONT, 10.0);
+
+    geode->getOrCreateStateSet()->setAttribute(material);    
+}
+
+void RigidBodyStateVisualization::setTexture(QString const& path)
+{ return setTexture(path.toStdString()); }
+
+void RigidBodyStateVisualization::setTexture(std::string const& path)
+{
+    if (path.empty())
+        return clearTexture();
+    
+    QString qt_path = createAbsolutePath(path);
+    
+    image = osgDB::readImageFile(qt_path.toStdString());
+    if(image == NULL) {
+        return;
+    }
+    texture_dirty = true;
+    texture_path = path;
+}
+
+QString RigidBodyStateVisualization::getTexture() const {
+    return QString(texture_path.c_str());
+}
+
+void RigidBodyStateVisualization::clearTexture()
+{
+    image.release();
+    texture_dirty = true;
+}
+
+void RigidBodyStateVisualization::addBumpMapping(
+                QString const& diffuse_color_map_path,
+                QString const& normal_map_path)
+{
+    return addBumpMapping(diffuse_color_map_path.toStdString(), 
+            normal_map_path.toStdString()); 
+}
+        
+void RigidBodyStateVisualization::addBumpMapping(
+                std::string const& diffuse_color_map_path,
+                std::string const& normal_map_path)
+{   
+    if(body_model == NULL) {
+        return;
+    }
+           
+    if (!body_model->asGeode()) {
+        std::cerr << "model is not a geode, cannot use bump mapping" << std::endl;
+        return;
+    } else if ( !body_model->asGeode()->getDrawable(0) || 
+                !body_model->asGeode()->getDrawable(0)->asGeometry()) {
+        std::cerr << "model does not contain a mesh, cannot use bump mapping" << std::endl;
+        return;
+    }
+
+    // Setup the textures
+    diffuse_image = osgDB::readImageFile(diffuse_color_map_path);
+    normal_image  = osgDB::readImageFile(normal_map_path);
+
+    // And add bump mapping
+    osgFX::BumpMapping* bump_mapping = new osgFX::BumpMapping();
+    bump_mapping->setLightNumber(0);
+    bump_mapping->setNormalMapTextureUnit(1);
+    bump_mapping->setDiffuseTextureUnit(2);
+    this->bump_mapping = bump_mapping;
+    bump_mapping_dirty = true;
+}
+
+void RigidBodyStateVisualization::removeBumpMapping()
+{
+    bump_mapping.release();
+    bump_mapping_dirty = true;
+}
+
+QVector3D RigidBodyStateVisualization::getTranslation() const
+{
+    return QVector3D(translation.x(), translation.y(), translation.z());
+}
+
+void RigidBodyStateVisualization::setTranslation(QVector3D const& v)
+{
+    translation = osg::Vec3(v.x(), v.y(), v.z());
+    setDirty();
+}
+
+void RigidBodyStateVisualization::setRotation(QQuaternion const& q)
+{
+    rotation = osg::Quat(q.x(), q.y(), q.z(), q.scalar());
+    setDirty();
+}
+
+// PRIVATE
+ref_ptr<Group> RigidBodyStateVisualization::createSimpleSphere(double size)
+{   
+    ref_ptr<Group> group = new Group();
+    
+    ref_ptr<Geode> geode = new Geode();
+    ref_ptr<Sphere> sp = new Sphere(Vec3f(0,0,0), main_size * size);
+    ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
+    spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
+    geode->addDrawable(spd);
+    group->addChild(geode);
+    
+    return group;
+}
+  
+ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
+{   
+    ref_ptr<Group> group = new Group();
+    
+    ref_ptr<Geode> geode = new Geode();
+    ref_ptr<Sphere> sp = new Sphere(Vec3f(0,0,0), main_size * size);
+    ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
+    spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
+    geode->addDrawable(spd);
+    group->addChild(geode);
+    
+    //up
+    ref_ptr<Geode> c1g = new Geode();
+    ref_ptr<Cylinder> c1 = new Cylinder(Vec3f(0, 0, size / 2), size / 40, size);
+    ref_ptr<ShapeDrawable> c1d = new ShapeDrawable(c1);
+    c1g->addDrawable(c1d);
+    setColor(Vec4f(0, 0, 1.0, 1.0), c1g);
+    group->addChild(c1g);
+    
+    //north direction
+    ref_ptr<Geode> c2g = new Geode();
+    ref_ptr<Cylinder> c2 = new Cylinder(Vec3f(0, size / 2, 0), size / 40, size);
+    c2->setRotation(Quat(M_PI/2.0, Vec3d(1,0,0)));
+    ref_ptr<ShapeDrawable> c2d = new ShapeDrawable(c2);
+    c2g->addDrawable(c2d);
+    setColor(Vec4f(0.0, 1.0, 0, 1.0), c2g);
+    group->addChild(c2g);
+
+    //east
+    ref_ptr<Geode> c3g = new Geode();
+    ref_ptr<Cylinder> c3 = new Cylinder(Vec3f(size / 2, 0, 0), size / 40, size);
+    c3->setRotation(Quat(M_PI/2.0, Vec3d(0,1,0)));
+    ref_ptr<ShapeDrawable> c3d = new ShapeDrawable(c3);
+    c3g->addDrawable(c3d);
+    setColor(Vec4f(1.0, 0.0, 0, 1.0), c3g);
+    group->addChild(c3g);
+
+    return group;
+}
+
+void RigidBodyStateVisualization::updateTexture()
+{
+    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
+    if (!image)
+    {
+        state->setTextureMode(0, GL_TEXTURE_2D, StateAttribute::OFF);
+        return;
+    }
+    else
+    {
+        texture->setImage(image.get());
+        state->setTextureAttributeAndModes(0, texture, StateAttribute::ON);
+    }
+}
+
+void RigidBodyStateVisualization::updateBumpMapping()
+{
+    ref_ptr<StateSet> state = body_model->getOrCreateStateSet();
+
+    if (!bump_mapping)
+    {
+        diffuse_image.release();
+        normal_image.release();
+        state->setTextureMode(1, GL_TEXTURE_2D, StateAttribute::OFF);
+        state->setTextureMode(2, GL_TEXTURE_2D, StateAttribute::OFF);
+        return;
+    }
+    else
+    {
+        ref_ptr<Geometry> geometry = body_model->asGeode()->getDrawable(0)->asGeometry();
+        ref_ptr<Array> tex_coord = geometry->getTexCoordArray(0);
+        geometry->setTexCoordArray(1, tex_coord);
+        geometry->setTexCoordArray(2, tex_coord);
+
+        diffuse_texture->setImage(diffuse_image.get());
+        normal_texture->setImage(normal_image.get());
+        state->setTextureAttributeAndModes(1, normal_texture, StateAttribute::ON);
+        state->setTextureAttributeAndModes(2, diffuse_texture, StateAttribute::ON);
+        bump_mapping->prepareChildren();
+    }
 }
 
 QString RigidBodyStateVisualization::createAbsolutePath(std::string const& path){

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -192,18 +192,6 @@ ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
     ref_ptr<ShapeDrawable> spd = new ShapeDrawable(sp);
     spd->setColor(Vec4f(color.x(), color.y(), color.z(), 1.0));
     geode->addDrawable(spd);
-    /*
-    if(text_size > 0.0)
-    {
-        double actual_size = text_size * size;
-        ref_ptr<osgText::Text> text= new osgText::Text;
-        text->setText(state.sourceFrame);
-        text->setCharacterSize(actual_size);
-        text->setPosition(osg::Vec3d(actual_size/2,actual_size/2,0));
-        geode->addDrawable(text);
-    }
-    */
-
     group->addChild(geode);
     
     //up
@@ -428,8 +416,11 @@ void RigidBodyStateVisualization::updateMainNode(Node* node)
     if (!body_model) {
         resetModel(total_size);
     }
-    //if (texture_dirty)
+    
+    //if (texture_dirty) {
     //    updateTexture();
+    //}
+    
     // Bump mapping not added yet, seems not to work anyway.
     //if (bump_mapping_dirty)
     //    updateBumpMapping();
@@ -437,6 +428,19 @@ void RigidBodyStateVisualization::updateMainNode(Node* node)
     std::vector<base::samples::RigidBodyState>::iterator it;
     for(it = states.begin(); it != states.end(); it++) {
         PositionAttitudeTransform* body_pose = new PositionAttitudeTransform();
+        
+        // Add texture.
+        if(text_size > 0.0 && !it->sourceFrame.empty())
+        {
+            ref_ptr<Geode> geode = new Geode();
+            double actual_size = text_size * total_size;
+            ref_ptr<osgText::Text> text= new osgText::Text;
+            text->setText(it->sourceFrame);
+            text->setCharacterSize(actual_size);
+            text->setPosition(osg::Vec3d(actual_size/2,actual_size/2,0));
+            geode->addDrawable(text);
+            body_pose->addChild(geode);
+        }
         
         body_pose->addChild(body_model);
         group->addChild(body_pose);

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -206,7 +206,7 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
         resetModelSphere(total_size);
         return;
     }
-    else if (path == "simple")
+    else if (path == "simple" || path.empty())
     {
         resetModel(total_size);
         return;

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -71,9 +71,19 @@ void RigidBodyStateVisualization::setTexture(std::string const& path)
 {
     if (path.empty())
         return clearTexture();
-
-    image = osgDB::readImageFile(path);
+    
+    QString qt_path = createAbsolutePath(path);
+    
+    image = osgDB::readImageFile(qt_path.toStdString());
+    if(image == NULL) {
+        return;
+    }
     texture_dirty = true;
+    texture_path = path;
+}
+
+QString RigidBodyStateVisualization::getTexture() const {
+    return QString(texture_path.c_str());
 }
 
 void RigidBodyStateVisualization::clearTexture()
@@ -149,7 +159,6 @@ void RigidBodyStateVisualization::updateBumpMapping()
     }
     else
     {
-
         ref_ptr<Geometry> geometry = body_model->asGeode()->getDrawable(0)->asGeometry();
         ref_ptr<Array> tex_coord = geometry->getTexCoordArray(0);
         geometry->setTexCoordArray(1, tex_coord);
@@ -306,13 +315,7 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
         return;
     }
 
-    // Creates an absolute file path.
-    QString qt_path(path.c_str());
-    if (qt_path.startsWith ("~/")) {
-        qt_path.replace (0, 1, QDir::homePath());
-    }   
-    QDir dir(qt_path);
-    qt_path = dir.absolutePath();
+    QString qt_path = createAbsolutePath(path);
     
     // If the model cannot be opened, NULL will be returned.
     ref_ptr<Node> model = osgDB::readNodeFile(qt_path.toStdString());
@@ -417,9 +420,9 @@ void RigidBodyStateVisualization::updateMainNode(Node* node)
         resetModel(total_size);
     }
     
-    //if (texture_dirty) {
-    //    updateTexture();
-    //}
+    if (texture_dirty) {
+        updateTexture();
+    }
     
     // Bump mapping not added yet, seems not to work anyway.
     //if (bump_mapping_dirty)
@@ -499,4 +502,14 @@ void RigidBodyStateVisualization::updateDataIntern( const std::vector<base::samp
     this->states = states; 
 }
 
+QString RigidBodyStateVisualization::createAbsolutePath(std::string const& path){
+    QString qt_path(path.c_str());
+    if (qt_path.startsWith ("~/")) {
+        qt_path.replace (0, 1, QDir::homePath());
+    }   
+    QDir dir(qt_path);
+    qt_path = dir.absolutePath();
+    return qt_path;
 }
+
+} // end namespace vizkit3d 

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -16,7 +16,8 @@ namespace osgFX
 namespace vizkit3d 
 {
 
-class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBodyState>
+class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBodyState>,
+        public VizPluginAddType<std::vector <base::samples::RigidBodyState> >
 {
         Q_OBJECT
         Q_PROPERTY(double size READ getSize WRITE setSize)
@@ -37,12 +38,15 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         { return Vizkit3DPlugin<base::samples::RigidBodyState>::updateData(state); }
         Q_INVOKABLE void updateRigidBodyState( const base::samples::RigidBodyState& state )
         { return updateData(state); }
+        Q_INVOKABLE void updateData( const std::vector<base::samples::RigidBodyState>& states )
+        { return Vizkit3DPlugin<base::samples::RigidBodyState>::updateData(states); }
 
     protected:
         virtual osg::ref_ptr<osg::Node> createMainNode();
         virtual void updateMainNode(osg::Node* node);
         void updateDataIntern( const base::samples::RigidBodyState& state );
-        base::samples::RigidBodyState state;
+        void updateDataIntern( const std::vector<base::samples::RigidBodyState>& states );
+        std::vector<base::samples::RigidBodyState> states;
     
     public slots: 
         bool isPositionDisplayForced() const;

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -29,9 +29,9 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         Q_PROPERTY(QString modelPath READ getModelPath WRITE loadModel)
 
     public:
-	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	RigidBodyStateVisualization(QObject* parent = NULL);
-	virtual ~RigidBodyStateVisualization();
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        RigidBodyStateVisualization(QObject* parent = NULL);
+        virtual ~RigidBodyStateVisualization();
 
         Q_INVOKABLE void updateData( const base::samples::RigidBodyState& state )
         { return Vizkit3DPlugin<base::samples::RigidBodyState>::updateData(state); }
@@ -40,8 +40,8 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 
     protected:
         virtual osg::ref_ptr<osg::Node> createMainNode();
-	virtual void updateMainNode(osg::Node* node);
-	void updateDataIntern( const base::samples::RigidBodyState& state );
+        virtual void updateMainNode(osg::Node* node);
+        void updateDataIntern( const base::samples::RigidBodyState& state );
         base::samples::RigidBodyState state;
     
     public slots: 
@@ -54,7 +54,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         void setSize(double size);
 
         void resetModel(double size);
-	void resetModelSphere(double size);
+        void resetModelSphere(double size);
 	
         QString getModelPath() const;
         void loadModel(std::string const& path);
@@ -95,7 +95,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
          */
         void setColor(base::Vector3d const& color);
 	
-	void setColor(const osg::Vec4d& color, osg::Geode* geode);
+        void setColor(const osg::Vec4d& color, osg::Geode* geode);
 	
         void setTexture(QString const& path);
         void setTexture(std::string const& path);
@@ -127,9 +127,9 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         { BODY_NONE, BODY_SIMPLE, BODY_SPHERE, BODY_CUSTOM_MODEL };
 
         BODY_TYPES body_type;
-	osg::ref_ptr<osg::Node>  body_model;
+        osg::ref_ptr<osg::Node>  body_model;
         osg::ref_ptr<osg::Group> createSimpleBody(double size);
-	osg::ref_ptr<osg::Group> createSimpleSphere(double size);
+        osg::ref_ptr<osg::Group> createSimpleSphere(double size);
 
         osg::ref_ptr<osg::Image> image;
         osg::ref_ptr<osg::Texture2D> texture;

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -28,6 +28,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         Q_PROPERTY(bool forcePositionDisplay READ isPositionDisplayForced WRITE setPositionDisplayForceFlag)
         Q_PROPERTY(bool forceOrientationDisplay READ isOrientationDisplayForced WRITE setOrientationDisplayForceFlag)
         Q_PROPERTY(QString modelPath READ getModelPath WRITE loadModel)
+        Q_PROPERTY(QString texturePath READ getTexture WRITE setTexture)
 
     public:
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -103,6 +104,8 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 	
         void setTexture(QString const& path);
         void setTexture(std::string const& path);
+        QString getTexture() const;
+        
         void clearTexture();
         void addBumpMapping(
                 QString const& diffuse_color_map_path,
@@ -152,7 +155,9 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         bool forceOrientationDisplay;
         
         QString model_path;
-
+        std::string texture_path;
+        
+        QString createAbsolutePath(std::string const& path);
 };
 
 }

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -55,9 +55,6 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         bool isOrientationDisplayForced() const;
         void setOrientationDisplayForceFlag(bool flag);
 
-        double getSize() const;
-        void setSize(double size);
-
         void resetModel(double size);
         void resetModelSphere(double size);
 	
@@ -78,6 +75,9 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
          * The default is 0.1
          */
         double getMainSphereSize() const;
+        
+        double getSize() const;
+        void setSize(double size);
 
         /** Sets the text size relative to the size of the complete object.
          * If text size is positive, the name of the source frame is rendered in the visualization.
@@ -99,14 +99,13 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
          * apply the new color
          */
         void setColor(base::Vector3d const& color);
-	
         void setColor(const osg::Vec4d& color, osg::Geode* geode);
 	
         void setTexture(QString const& path);
         void setTexture(std::string const& path);
-        QString getTexture() const;
-        
+        QString getTexture() const;     
         void clearTexture();
+        
         void addBumpMapping(
                 QString const& diffuse_color_map_path,
                 QString const& normal_map_path);
@@ -135,13 +134,10 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 
         BODY_TYPES body_type;
         osg::ref_ptr<osg::Node>  body_model;
-        osg::ref_ptr<osg::Group> createSimpleBody(double size);
-        osg::ref_ptr<osg::Group> createSimpleSphere(double size);
 
         osg::ref_ptr<osg::Image> image;
         osg::ref_ptr<osg::Texture2D> texture;
         bool texture_dirty;
-        void updateTexture();
 
         osg::ref_ptr<osg::Image> diffuse_image;
         osg::ref_ptr<osg::Image> normal_image;
@@ -149,7 +145,6 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         osg::ref_ptr<osg::Texture2D> normal_texture;
         osg::ref_ptr<osgFX::BumpMapping> bump_mapping;
         bool bump_mapping_dirty;
-        void updateBumpMapping();
 
         bool forcePositionDisplay;
         bool forceOrientationDisplay;
@@ -157,6 +152,10 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         QString model_path;
         std::string texture_path;
         
+        osg::ref_ptr<osg::Group> createSimpleBody(double size);
+        osg::ref_ptr<osg::Group> createSimpleSphere(double size);
+        void updateTexture();
+        void updateBumpMapping();
         QString createAbsolutePath(std::string const& path);
 };
 

--- a/viz/vizkit_plugin.rb
+++ b/viz/vizkit_plugin.rb
@@ -11,6 +11,7 @@ Vizkit::UiLoader.register_3d_plugin('RigidBodyStateVisualization',"base", 'Rigid
 Vizkit::UiLoader.register_3d_plugin_for('RigidBodyStateVisualization', "/base/samples/RigidBodyState", :updateRigidBodyState)
 Vizkit::UiLoader.register_3d_plugin('BodyStateVisualization',"base", 'BodyStateVisualization')
 Vizkit::UiLoader.register_3d_plugin_for('BodyStateVisualization', "/base/samples/BodyState", :updateBodyState)
+Vizkit::UiLoader.register_3d_plugin_for('RigidBodyStateVisualization', "/std/vector</base/samples/RigidBodyState>", :updateData)
 Vizkit::UiLoader.register_3d_plugin('LaserScanVisualization',"base", 'LaserScanVisualization')
 Vizkit::UiLoader.register_3d_plugin_for('LaserScanVisualization', "/base/samples/LaserScan", :updateLaserScan)
 Vizkit::UiLoader.register_3d_plugin('MotionCommandVisualization',"base", 'MotionCommandVisualization')


### PR DESCRIPTION
Allows to visualize vectors of RGBs, fixes some bugs (crash if a model could not be loaded), does some formatting and adapts the order of the methods within header and source file (reason why so much changes are shown).

Images can be load as textures again, but bump mapping is still not available (remove completely?).