### PR TITLE
viz/PluginLoader bugfixes

### DIFF
--- a/viz/PluginLoader.cpp
+++ b/viz/PluginLoader.cpp
@@ -11,11 +11,11 @@
 #include "DepthMapVisualization.hpp"
 
 namespace vizkit3d {
-    class QtPluginVizkit : public vizkit3d::VizkitPluginFactory {
+    class QtPluginVizkitBase : public vizkit3d::VizkitPluginFactory {
     private:
     public:
 	
-	QtPluginVizkit() {
+	QtPluginVizkitBase() {
 	}
 	
 	/**
@@ -89,5 +89,5 @@ namespace vizkit3d {
 	    return NULL;
         };
     };
-    Q_EXPORT_PLUGIN2(QtPluginVizkit, QtPluginVizkit)
+    Q_EXPORT_PLUGIN2(QtPluginVizkitBase, QtPluginVizkitBase)
 }

--- a/viz/PluginLoader.cpp
+++ b/viz/PluginLoader.cpp
@@ -32,7 +32,6 @@ namespace vizkit3d {
 	    pluginNames->push_back("BodyStateVisualization");
 	    pluginNames->push_back("LaserScanVisualization");
 	    pluginNames->push_back("SonarGroundDistanceVisualization");
-	    pluginNames->push_back("GridVisualization");
 	    pluginNames->push_back("PointcloudVisualization");
 	    pluginNames->push_back("SonarBeamVisualization");
 	    pluginNames->push_back("DepthMapVisualization");


### PR DESCRIPTION
This PR contains a minor and a major bugfix.

**Minor**: The QtPluginVizkit claimed to provide GridVisualization but it didnt. Fixed by removing the entry from `pluginNames`.

**Major**: `QtPluginVizkit` is also the name of the plugin factory in Vizkit3d. Thus when loading libbase-viz and libvizkit3d-viz you would get name clashes. Those led to strange behavior in Vizkit3d. This was fixed by renaming `QtPluginVizkit` to `QtPluginVizkitBase`.