### PR TITLE
fixed non templated quaternions in depth map conversion method

### DIFF
--- a/base/samples/DepthMap.hpp
+++ b/base/samples/DepthMap.hpp
@@ -338,8 +338,8 @@ public:
 	computeLocalTransformations(rows2column, columns2pointcloud, use_lut);
 	
 	Eigen::Matrix<typename T::Scalar,3,1> translation_delta = last_transformation.translation() - first_transformation.translation();
-	Eigen::Quaterniond first_rotation = Eigen::Quaterniond(first_transformation.linear());
-	Eigen::Quaterniond last_rotation = Eigen::Quaterniond(last_transformation.linear());
+	Eigen::Quaternion<typename T::Scalar> first_rotation = Eigen::Quaternion<typename T::Scalar>(first_transformation.linear());
+	Eigen::Quaternion<typename T::Scalar> last_rotation = Eigen::Quaternion<typename T::Scalar>(last_transformation.linear());
 	
 	// apply global interpolated transformations
 	if(!apply_transforms_vertically)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -612,7 +612,29 @@ BOOST_AUTO_TEST_CASE(depth_map_test)
     BOOST_CHECK(scan_points.size() == 8);
     for(unsigned i = 0; i < scan_points.size(); i++)
 	BOOST_CHECK(scan_points[i].isApprox(transformations[(i%2==0)?0:1] * ref_points[i], 1e-12));
-    
+
+    // check transformation with float types
+    std::vector<Eigen::Vector3f> scan_points_f;
+    Eigen::Affine3f transform_f = Eigen::Affine3f::Identity();
+    scan.convertDepthMapToPointCloud(scan_points_f, transform_f);
+    BOOST_CHECK(scan_points_f.size() == 8);
+    for(unsigned i = 0; i < scan_points_f.size(); i++)
+        BOOST_CHECK(scan_points_f[i].isApprox(ref_points[i].cast<float>(), 1e-6));
+
+    scan_points_f.clear();
+    scan.convertDepthMapToPointCloud(scan_points_f, transform_f, transform_f);
+    BOOST_CHECK(scan_points_f.size() == 8);
+    for(unsigned i = 0; i < scan_points_f.size(); i++)
+        BOOST_CHECK(scan_points_f[i].isApprox(ref_points[i].cast<float>(), 1e-6));
+
+    scan_points_f.clear();
+    std::vector<Eigen::Affine3f> transformations_f;
+    transformations_f.push_back(transform_f);
+    transformations_f.push_back(transform_f);
+    scan.convertDepthMapToPointCloud(scan_points_f, transformations_f, true, true, false);
+    BOOST_CHECK(scan_points_f.size() == 8);
+    for(unsigned i = 0; i < scan_points_f.size(); i++)
+        BOOST_CHECK(scan_points_f[i].isApprox(ref_points[i].cast<float>(), 1e-6));
     
     
     // Test vertical irregular transformation


### PR DESCRIPTION
This fixes the issue that this particular conversion method couldn't be used with floating point transformations.