### PR TITLE
New transformation type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ rock_library(
         samples/Sonar.cpp
         samples/SonarBeam.cpp
         samples/SonarScan.cpp
+        samples/PoseWithCovariance.cpp
     HEADERS
         Angle.hpp
         CircularBuffer.hpp
@@ -79,6 +80,7 @@ rock_library(
         samples/Sonar.hpp
         samples/SonarBeam.hpp
         samples/SonarScan.hpp
+        samples/PoseWithCovariance.hpp
         samples/Wrench.hpp
         samples/Wrenches.hpp
         templates/TimeStamped.hpp

--- a/src/samples/PoseWithCovariance.cpp
+++ b/src/samples/PoseWithCovariance.cpp
@@ -1,0 +1,75 @@
+#include "PoseWithCovariance.hpp"
+
+namespace base { namespace samples {
+
+PoseWithCovariance::PoseWithCovariance()
+{
+
+}
+
+PoseWithCovariance::PoseWithCovariance(const TransformWithCovariance& transform) :
+        transform(transform.translation, transform.orientation, transform.cov)
+{
+
+}
+
+PoseWithCovariance::PoseWithCovariance(const RigidBodyState& rbs) : time(rbs.time),
+    frame_id(rbs.targetFrame), object_frame_id(rbs.sourceFrame), transform(rbs.position, rbs.orientation)
+{
+    transform.cov << rbs.cov_position, Eigen::Matrix3d::Zero(),
+                        Eigen::Matrix3d::Zero(), rbs.cov_orientation;
+}
+
+PoseWithCovariance PoseWithCovariance::operator*(const PoseWithCovariance& pose) const
+{
+    // compose new pose
+    PoseWithCovariance new_pose;
+    new_pose.time.microseconds = std::max(this->time.microseconds, pose.time.microseconds);
+    new_pose.object_frame_id = pose.object_frame_id;
+    new_pose.frame_id = this->frame_id;
+    new_pose.transform = this->transform * pose.transform;
+    return new_pose;
+}
+
+void PoseWithCovariance::setTransform(const TransformWithCovariance& transform)
+{
+    this->transform = transform;
+}
+
+void PoseWithCovariance::setTransform(const Eigen::Affine3d& transform)
+{
+    this->transform.setTransform(transform);
+}
+
+const TransformWithCovariance& PoseWithCovariance::getTransformWithCovariance() const
+{
+    return transform;
+}
+
+Eigen::Affine3d PoseWithCovariance::getTransform() const
+{
+    return transform.getTransform();
+}
+
+const TransformWithCovariance::Covariance& PoseWithCovariance::getCovariance() const
+{
+    return transform.getCovariance();
+}
+
+RigidBodyState PoseWithCovariance::toRigidBodyState() const
+{
+    base::samples::RigidBodyState rbs;
+    rbs.time = time;
+    rbs.targetFrame = frame_id;
+    rbs.sourceFrame = object_frame_id;
+    rbs.position = transform.translation;
+    rbs.orientation = transform.orientation;
+    if(transform.hasValidCovariance())
+    {
+        rbs.cov_position = transform.getTranslationCov();
+        rbs.cov_orientation = transform.getOrientationCov();
+    }
+    return rbs;
+}
+
+}}

--- a/src/samples/PoseWithCovariance.hpp
+++ b/src/samples/PoseWithCovariance.hpp
@@ -1,0 +1,80 @@
+#ifndef BASE_SAMPLES_POSE_WITH_COVARIANCE_HPP
+#define BASE_SAMPLES_POSE_WITH_COVARIANCE_HPP
+
+#include <string>
+#include <base/Time.hpp>
+#include <base/TransformWithCovariance.hpp>
+#include <base/samples/RigidBodyState.hpp>
+
+namespace base { namespace samples {
+
+/**
+ * Represents a 3D pose with uncertainty of the frame 'object_frame_id' in the frame 'frame_id'.
+ * A frame ID shall be globally unique and correspond to a coordinate system.
+ * Following the [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards)
+ * coordinate systems are right handed with X forward, Y left and Z up.
+ *
+ * The pose \f$ ^{reference}_{object}T \f$ in this structure transforms a vector \f$ v_{object} \f$
+ * from the object frame to the reference frame:
+ * \f$ v_{reference} = ^{reference}_{object}T \cdot v_{object} \f$
+ * Example of a transformation chain:
+ * \f$ ^{world}_{sensor}T = ^{world}_{body}T \cdot ^{body}_{sensor}T \f$
+ */
+class PoseWithCovariance
+{
+public:
+    /** Reference timestamp of the pose sample */
+    base::Time time;
+
+    /** ID of the reference frame where this pose is expressed in */
+    std::string frame_id;
+
+    /** ID of the object frame defined by this pose */
+    std::string object_frame_id;
+
+    /** Pose of the object frame in the reference frame */
+    base::TransformWithCovariance transform;
+
+public:
+    /** Default constructor */
+    PoseWithCovariance();
+
+    /** Initializes type from a TransformWithCovariance */
+    explicit PoseWithCovariance(const base::TransformWithCovariance& transform);
+
+    /** Initializes type from a RigidBodyState */
+    explicit PoseWithCovariance(const base::samples::RigidBodyState& rbs);
+
+    /** Performs a composition of this pose with a given pose.
+    * The result is another pose with result = this * pose.
+    * The frame ID's will be set accordingly (e.g. a_in_b = c_in_b * a_in_c).
+    * Note that this method doesn't check if the composition
+    * is frame wise valid.
+    */
+    PoseWithCovariance operator*(const PoseWithCovariance& pose) const;
+
+    /** Sets the transformation as TransformWithCovariance */
+    void setTransform(const base::TransformWithCovariance& transform);
+
+    /** Sets the transformation as Eigen::Affine3d */
+    void setTransform(const Eigen::Affine3d& transform);
+
+    /** Returns transformation as TransformWithCovariance */
+    const base::TransformWithCovariance& getTransformWithCovariance() const;
+
+    /** Returns transformation as Eigen::Affine3d */
+    Eigen::Affine3d getTransform() const;
+
+    /** Returns the 6x6 covariance matrix */
+    const base::TransformWithCovariance::Covariance& getCovariance() const;
+
+    /** Converts the type to a RigidBodyState.
+     * Note that the cross-covariances will be lost,
+     * since the RigidBodyState does not store them.
+     */
+    base::samples::RigidBodyState toRigidBodyState() const;
+};
+
+}}
+
+#endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -32,6 +32,7 @@
 #include <base/samples/DepthMap.hpp>
 #include <base/TransformWithCovariance.hpp>
 #include <base/samples/Sonar.hpp>
+#include <base/samples/PoseWithCovariance.hpp>
 #include <base/Temperature.hpp>
 #include <base/Time.hpp>
 #include <base/TimeMark.hpp>
@@ -1472,6 +1473,85 @@ BOOST_AUTO_TEST_CASE( transform_with_covariance )
 
     BOOST_CHECK( t1.getTransform().matrix().isApprox( t1r.getTransform().matrix(), sigma ) );
     BOOST_CHECK( t1.getCovariance().isApprox( t1r.getCovariance(), sigma ) );
+}
+
+BOOST_AUTO_TEST_CASE( pose_with_covariance )
+{
+    base::samples::RigidBodyState rbs;
+    rbs.time = base::Time::fromSeconds(1000);
+    rbs.sourceFrame = "laser";
+    rbs.targetFrame = "body";
+    rbs.position = base::Vector3d(1,2,3);
+    rbs.cov_position = 0.1 * base::Matrix3d::Identity();
+    rbs.orientation = Eigen::AngleAxisd(0.5*M_PI,Eigen::Vector3d::UnitZ()) *
+                        Eigen::AngleAxisd(-0.2*M_PI,Eigen::Vector3d::UnitY()) *
+                        Eigen::AngleAxisd(0.1*M_PI,Eigen::Vector3d::UnitX());
+    rbs.cov_orientation = 0.02 * base::Matrix3d::Identity();
+
+    base::samples::PoseWithCovariance t(rbs);
+    BOOST_CHECK(rbs.time == t.time);
+    BOOST_CHECK(rbs.sourceFrame == t.object_frame_id);
+    BOOST_CHECK(rbs.targetFrame == t.frame_id);
+    BOOST_CHECK(rbs.position.isApprox(t.transform.translation, 1e-12));
+    BOOST_CHECK(rbs.cov_position.isApprox(t.transform.getTranslationCov(), 1e-12));
+    BOOST_CHECK(rbs.orientation.isApprox(t.transform.orientation, 1e-12));
+    BOOST_CHECK(rbs.cov_orientation.isApprox(t.transform.getOrientationCov(), 1e-12));
+
+    base::samples::RigidBodyState rbs2 = t.toRigidBodyState();
+    BOOST_CHECK(rbs.time == rbs2.time);
+    BOOST_CHECK(rbs.sourceFrame == rbs2.sourceFrame);
+    BOOST_CHECK(rbs.targetFrame == rbs2.targetFrame);
+    BOOST_CHECK(rbs.position.isApprox(rbs2.position, 1e-12));
+    BOOST_CHECK(rbs.cov_position.isApprox(rbs2.cov_position, 1e-12));
+    BOOST_CHECK(rbs.orientation.isApprox(rbs2.orientation, 1e-12));
+    BOOST_CHECK(rbs.cov_orientation.isApprox(rbs2.cov_orientation, 1e-12));
+
+    // test operator*
+    base::Matrix6d lt1;
+    lt1 <<
+        0.1, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, -3.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, -2.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, -1.0;
+    base::samples::PoseWithCovariance body_in_world(base::TransformWithCovariance(
+            Eigen::Affine3d(Eigen::Translation3d(Eigen::Vector3d(1,0,0)) * Eigen::AngleAxisd( M_PI/2.0, Eigen::Vector3d::UnitX()) ),
+            lt1 ));
+    body_in_world.time = base::Time();
+
+    base::Matrix6d lt2;
+    lt2 <<
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.2, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 2.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 3.0;
+    base::samples::PoseWithCovariance sensor_in_body(base::TransformWithCovariance(
+            Eigen::Affine3d(Eigen::Translation3d(Eigen::Vector3d(0,1,2)) * Eigen::AngleAxisd( M_PI/2.0, Eigen::Vector3d::UnitY()) ),
+            lt2 ));
+    sensor_in_body.time = base::Time::now();
+
+    body_in_world.frame_id = "world";
+    body_in_world.object_frame_id = "body";
+    sensor_in_body.object_frame_id = "sensor";
+    sensor_in_body.frame_id = "body";
+    base::samples::PoseWithCovariance sensor_in_world = body_in_world * sensor_in_body;
+
+    // check composition
+    BOOST_CHECK(sensor_in_world.object_frame_id == sensor_in_body.object_frame_id);
+    BOOST_CHECK(sensor_in_world.frame_id == body_in_world.frame_id);
+    BOOST_CHECK(sensor_in_world.time == sensor_in_body.time);
+
+    base::samples::PoseWithCovariance body_in_world_r(sensor_in_world.transform.compositionInv(sensor_in_body.transform));
+    base::samples::PoseWithCovariance sensor_in_body_r(sensor_in_world.transform.preCompositionInv(body_in_world.transform));
+
+    BOOST_CHECK( body_in_world.getTransform().matrix().isApprox( body_in_world_r.getTransform().matrix(), 1e-12 ) );
+    BOOST_CHECK( body_in_world.getCovariance().isApprox( body_in_world_r.getCovariance(), 1e-12 ) );
+
+    BOOST_CHECK( sensor_in_body.getTransform().matrix().isApprox( sensor_in_body_r.getTransform().matrix(), 1e-12 ) );
+    BOOST_CHECK( sensor_in_body.getCovariance().isApprox( sensor_in_body_r.getCovariance(), 1e-12 ) );
 }
 
 #ifdef SISL_FOUND


### PR DESCRIPTION
This type shall be used in the future to express transformations.
I know that replacing the RigidBodyState will be a very long (and hard) process and I don't plan to force anyone to use this type. The idea is to first integrate this type in the back-end of the transformer while keeping the interfaces to the RigidBodyState and also add interfaces for the new type. At that point users could at least use the new type inside of their tasks and libraries already.

In contrast to the RigidBodyState this type has a full pose covariance matrix, no velocity members and a hopefully more intuitive frame naming.
