### PR TITLE
Let guaranteeSPD actually return a symmetric positive definite matrix.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 rock_testsuite(test_base_types test.cpp
     test_samples_Sonar.cpp
+    test_Eigen.cpp
     DEPS base
     DEPS_PKGCONFIG base-logging)
 rock_executable(benchmark benchmark.cpp bench_func.cpp

--- a/test/test_Eigen.cpp
+++ b/test/test_Eigen.cpp
@@ -1,0 +1,26 @@
+#include <boost/test/unit_test.hpp>
+#include <base/Eigen.hpp>
+#include <iostream>
+
+BOOST_AUTO_TEST_SUITE(Eigen)
+
+
+template<class Matrix>
+void test_SPD_helper(const Matrix& A, double precision)
+{
+    typedef typename Matrix::PlainObject Mat;
+    Mat B = base::guaranteeSPD(A+A.transpose(), precision);
+    Eigen::SelfAdjointEigenSolver<Mat> eig(B);
+    BOOST_CHECK((eig.eigenvalues().array()>=0.0).all());
+
+}
+
+BOOST_AUTO_TEST_CASE(test_SPD)
+{
+    test_SPD_helper(Eigen::Matrix4f::Random(), 1e-6);
+    test_SPD_helper(Eigen::Matrix3d::Random(), 1e-15);
+    test_SPD_helper(Eigen::MatrixXf::Random(10,10), 1e-6);
+    test_SPD_helper(Eigen::MatrixXd::Random(10,10), 1e-15);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The previous implementation was essentially a No-Op, because singular values are always non-negative by definition.
I don't know if this method was actually used somewhere, as it is unlikely to have made a difference ...
