### PR TITLE
Make explicit that body fixed frame is the sourceFrame

### DIFF
--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -61,7 +61,7 @@ namespace base { namespace samples {
 	 */
         base::Matrix3d cov_velocity;
 
-        /** Angular Velocity as an axis-angle representation in body fixed frame
+        /** Angular Velocity as an axis-angle representation in sourceFrame (body fixed frame)
          *
          * The direction of the vector is the axis, its length the speed */
         base::Vector3d angular_velocity;

--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -55,13 +55,15 @@ namespace base { namespace samples {
 	 */
         base::Matrix3d cov_orientation;
 
-        /** Velocity in m/s of sourceFrame expressed in targetFrame */
+        /** Velocity in m/s of sourceFrame relative to targetFrame,
+         * expressed in targetFrame */
         base::Vector3d velocity;
 	/** Covariance of the velocity 
 	 */
         base::Matrix3d cov_velocity;
 
-        /** Angular Velocity as an axis-angle representation in sourceFrame (body fixed frame)
+        /** Angular Velocity of sourceFrame relative to targetFrame,
+         * expressed in sourceFrame, as an axis-angle representation
          *
          * The direction of the vector is the axis, its length the speed */
         base::Vector3d angular_velocity;


### PR DESCRIPTION
As the frames are formally described as sourceFrame and targetFrame,
make it clear that the angular velocity is represented in sourceFrame.
Let an indication that it is the "body" frame, as in the RigidBodyState documentation
