### PR TITLE
ruby: create a RBS.invalid value only once and dup it

### DIFF
--- a/bindings/ruby/lib/base/typelib/rigid_body_state.rb
+++ b/bindings/ruby/lib/base/typelib/rigid_body_state.rb
@@ -1,23 +1,26 @@
 Typelib.specialize_model '/base/samples/RigidBodyState_m' do
     def invalid
-        v3 = { :data => [NaN] * 3 }
-        m3 = { :data => [NaN] * 9 }
-        new(
-            :time => Time.at(0),
-            :position => v3,
-            :cov_position => m3,
-            :orientation => { :im => [NaN, NaN, NaN], :re => NaN },
-            :cov_orientation => m3,
-            :velocity => v3,
-            :cov_velocity => m3,
-            :angular_velocity => v3,
-            :cov_angular_velocity => m3)
+        if !@invalid_sample
+            v3 = { data: [NaN] * 3 }
+            m3 = { data: [NaN] * 9 }
+            @invalid_sample = new(
+                time: Time.at(0),
+                position: v3,
+                cov_position: m3,
+                orientation: { im: [NaN, NaN, NaN], re: NaN },
+                cov_orientation: m3,
+                velocity: v3,
+                cov_velocity: m3,
+                angular_velocity: v3,
+                cov_angular_velocity: m3)
+        end
+        @invalid_sample.dup
     end
 
     def Invalid; invalid end
 
     def from_pose(pose)
-        rbs = new
+        rbs = invalid
         rbs.position = pose.position
         rbs.orientation = pose.orientation
         rbs


### PR DESCRIPTION
Just to avoid generating huge amounts of objects just to create
an invalid RBS