### PR TITLE
Fix of Eigen alignment exceptions with Depth Map

### DIFF
--- a/src/samples/DepthMap.hpp
+++ b/src/samples/DepthMap.hpp
@@ -239,8 +239,8 @@ public:
 	point_cloud.reserve(distances.size());
 	
 	// precompute local transformations
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > rows2column;
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > columns2pointcloud;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > rows2column;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > columns2pointcloud;
 	computeLocalTransformations(rows2column, columns2pointcloud, use_lut);
 	
 	// convert rows
@@ -282,8 +282,8 @@ public:
 	point_cloud.reserve(distances.size());
 	
 	// precompute local transformations
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > rows2column;
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > columns2pointcloud;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > rows2column;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > columns2pointcloud;
 	computeLocalTransformations(rows2column, columns2pointcloud, use_lut);
 	
 	Eigen::Matrix<typename T::Scalar,3,1> translation_delta = last_transformation.translation() - first_transformation.translation();
@@ -309,7 +309,7 @@ public:
 	}
 	else
 	{
-	    std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > pointcloud2world;
+	    std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > pointcloud2world;
 	    for(unsigned v = 0; v < vertical_size; v++)
 	    {
 		Eigen::Transform<typename T::Scalar,3,Eigen::Affine> transformation = 
@@ -339,7 +339,7 @@ public:
      */
     template<typename T>
     void convertDepthMapToPointCloud(std::vector<T> &point_cloud,
-				const std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> >& transformations,
+				const std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > >& transformations,
 				bool use_lut = false,
 				bool skip_invalid_measurements = true,
 				bool apply_transforms_vertically = true) const
@@ -358,8 +358,8 @@ public:
 	point_cloud.reserve(distances.size());
 	
 	// precompute local transformations
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > rows2column;
-	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > columns2pointcloud;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > rows2column;
+	std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > > columns2pointcloud;
 	computeLocalTransformations(rows2column, columns2pointcloud);
 	
 	// apply global transformations
@@ -398,7 +398,7 @@ protected:
     void convertSingleRow(std::vector<T> &point_cloud, 
 			    unsigned int row,
 			    const Eigen::Transform<typename T::Scalar,3,Eigen::Affine>& row2column,
-			    const std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> >& columns2pointcloud,
+			    const std::vector< Eigen::Transform<typename T::Scalar,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<typename T::Scalar,3,Eigen::Affine> > >& columns2pointcloud,
 			    const Eigen::Transform<typename T::Scalar,3,Eigen::Affine>& pointcloud2world,
 			    bool skip_invalid_measurements) const
     {
@@ -423,8 +423,8 @@ protected:
 
     /** Helper method to compute the local rows2column and columns2pointcloud transformations. */
     template<typename T>
-    void computeLocalTransformations(std::vector< Eigen::Transform<T,3,Eigen::Affine> >& rows2column, 
-				     std::vector< Eigen::Transform<T,3,Eigen::Affine> >& columns2pointcloud,
+    void computeLocalTransformations(std::vector< Eigen::Transform<T,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<T,3,Eigen::Affine> > >& rows2column, 
+				     std::vector< Eigen::Transform<T,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<T,3,Eigen::Affine> > >& columns2pointcloud,
 				     bool use_lut = false) const
     {
 	// check interval sizes
@@ -548,7 +548,7 @@ protected:
     
     /** Helper method to compute the rotations around an unit axis. */
     template<typename T>
-    void computeRotations(std::vector< Eigen::Transform<T,3,Eigen::Affine> >& rotations, 
+    void computeRotations(std::vector< Eigen::Transform<T,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<T,3,Eigen::Affine> > >& rotations, 
 			const std::vector<base::Angle>& angles, 
 			UNIT_AXIS axis,
 			bool use_lut = false) const
@@ -638,7 +638,7 @@ private:
     private:
 	double rad2deg;
 	double deg2rad;
-	std::vector< Eigen::Transform<T,3,Eigen::Affine> > transformations;
+	std::vector< Eigen::Transform<T,3,Eigen::Affine>, Eigen::aligned_allocator< Eigen::Transform<T,3,Eigen::Affine> > > transformations;
     };
 };
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(depth_map_test)
     
     
     // use multiple transformations
-    std::vector<Eigen::Affine3d> transformations;
+    std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d> > transformations;
     transformations.push_back(transform);
     transformations.push_back(transform * transform);
     scan_points.clear();
@@ -623,7 +623,7 @@ BOOST_AUTO_TEST_CASE(depth_map_test)
         BOOST_CHECK(scan_points_f[i].isApprox(ref_points[i].cast<float>(), 1e-6));
 
     scan_points_f.clear();
-    std::vector<Eigen::Affine3f> transformations_f;
+    std::vector<Eigen::Affine3f, Eigen::aligned_allocator<Eigen::Affine3f> > transformations_f;
     transformations_f.push_back(transform_f);
     transformations_f.push_back(transform_f);
     scan.convertDepthMapToPointCloud(scan_points_f, transformations_f, true, true, false);

--- a/viz/DepthMapVisualization.hpp
+++ b/viz/DepthMapVisualization.hpp
@@ -24,6 +24,8 @@ namespace vizkit3d
     Q_PROPERTY(QColor defaultFeatureColor READ getDefaultFeatureColor WRITE setDefaultFeatureColor)
     
     public:
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        
         DepthMapVisualization();
         ~DepthMapVisualization();
         


### PR DESCRIPTION
Fix for several instances of an Eigen alignment exception:

test-range: /usr/include/eigen3/Eigen/src/Core/DenseStorage.h:86: Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 16>::plain_array() [with T = double; int Size = 4; int MatrixOrArrayOptions = 0]: Assertion `(reinterpret_cast<size_t>(eigen_unaligned_array_assert_workaround_gcc47(array)) & 0xf) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.

In DepthMap.hpp: using Eigen::aligned_allocator in the declarations of std::vector containing Eigen vectors or matrices.

In DepthMapVisualization.hpp: adding the Eigen macro for the declaration of classes with Eigen vector/matrix members.