### PR TITLE
Changes in the behaviour of Timeout::timeLeft() to be consistent with documentation

### DIFF
--- a/src/JointLimitRange.cpp
+++ b/src/JointLimitRange.cpp
@@ -16,7 +16,7 @@ std::string JointLimitRange::OutOfBounds::errorString(std::string name, double m
 void JointLimitRange::validate(const JointState& state) const
 {
     std::pair<bool, OutOfBounds> check = verifyValidity(state);
-    if (check.first)
+    if (!check.first)
         throw check.second;
 }
 

--- a/src/Time.cpp
+++ b/src/Time.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <stdio.h>
 #include <time.h>
+#include <limits>
 
 namespace base {
 
@@ -133,12 +134,12 @@ int64_t Time::toMicroseconds() const
     return microseconds;
 }
 
-Time Time::fromMicroseconds(uint64_t value)
+Time Time::fromMicroseconds(int64_t value)
 {
     return Time(value);
 }
 
-Time Time::fromMilliseconds(uint64_t value)
+Time Time::fromMilliseconds(int64_t value)
 {
     return Time(value * 1000);
 }
@@ -163,6 +164,11 @@ Time Time::fromSeconds(double value)
     int64_t seconds = value;
     return Time(seconds * UsecPerSec + static_cast<int64_t>(round((value - seconds) * UsecPerSec)));
 }
+
+Time Time::max()
+{
+    return Time(std::numeric_limits<int64_t>::max());
+} 
 
 Time Time::fromTimeValues(int year, int month, int day, int hour, int minute, int seconds, int millis, int micros)
 {

--- a/src/Time.hpp
+++ b/src/Time.hpp
@@ -59,9 +59,9 @@ namespace base
         /** Returns this time as an integer number of microseconds */
         int64_t toMicroseconds() const;
         
-        static Time fromMicroseconds(uint64_t value);
+        static Time fromMicroseconds(int64_t value);
         
-	static Time fromMilliseconds(uint64_t value);
+	static Time fromMilliseconds(int64_t value);
         
         static Time fromSeconds(int64_t value);
         
@@ -70,7 +70,9 @@ namespace base
         static Time fromSeconds(int64_t value, int microseconds);
         
         static Time fromSeconds(double value);
-
+        
+        /** Returns the maximum time value possible */
+        static Time max();
 
         /**
           * \brief Create time from int Time Values.

--- a/src/Timeout.cpp
+++ b/src/Timeout.cpp
@@ -42,7 +42,7 @@ Time Timeout::timeLeft(const Time& timeout) const
     }
     else
     {
-        return Time::fromSeconds(0);
+        return Time::max();
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,11 @@
 rock_testsuite(test_base_types test.cpp
     test_samples_Sonar.cpp
     test_Eigen.cpp
+    test_Timeout.cpp
     DEPS base-types
     DEPS_PKGCONFIG base-logging)
 rock_executable(benchmark benchmark.cpp bench_func.cpp
     DEPS base-types
     DEPS_PKGCONFIG base-logging
     NOINSTALL)
+

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -380,6 +380,18 @@ BOOST_AUTO_TEST_CASE( time_test )
 {
     std::cout << base::Time::fromSeconds( 35.553 ) << std::endl;
     std::cout << base::Time::fromSeconds( -5.553 ) << std::endl;
+
+    base::Time null_time;
+    null_time.fromMicroseconds(0);
+    BOOST_CHECK(null_time.isNull());
+    null_time.fromMilliseconds(0);
+    BOOST_CHECK(null_time.isNull());
+
+
+    base::Time max_time;
+    max_time = base::Time::fromMicroseconds(std::numeric_limits<int64_t>::max());
+    BOOST_REQUIRE_EQUAL(max_time.toMicroseconds(), std::numeric_limits<int64_t>::max());
+    BOOST_REQUIRE_EQUAL(max_time, base::Time::max());
 }
 
 BOOST_AUTO_TEST_CASE( time_fromSeconds )
@@ -392,6 +404,51 @@ BOOST_AUTO_TEST_CASE( time_fromSeconds )
     BOOST_REQUIRE_EQUAL( -5553000, seconds.toMicroseconds() );
     seconds = base::Time::fromSeconds( 0.01 );
     BOOST_REQUIRE_EQUAL( 10000, seconds.toMicroseconds() );
+}
+
+BOOST_AUTO_TEST_CASE( time_fromMicroseconds )
+{
+    base::Time microseconds;
+
+    microseconds = base::Time::fromMicroseconds( -1 );
+    BOOST_REQUIRE_EQUAL( -1, microseconds.toMicroseconds() );
+    microseconds = base::Time::fromMicroseconds( 1 );
+    BOOST_REQUIRE_EQUAL( 1, microseconds.toMicroseconds() );
+}
+
+BOOST_AUTO_TEST_CASE( time_fromMilliseconds )
+{
+    base::Time milliseconds;
+
+    milliseconds = base::Time::fromMilliseconds( -1 );
+    BOOST_REQUIRE_EQUAL( -1000, milliseconds.toMicroseconds() );
+    milliseconds = base::Time::fromMilliseconds( 1 );
+    BOOST_REQUIRE_EQUAL( 1000, milliseconds.toMicroseconds() );
+}
+
+BOOST_AUTO_TEST_CASE(time_operators)
+{
+    base::Time time_10 = base::Time::fromMicroseconds(10);
+    base::Time time_1= base::Time::fromMicroseconds(1);
+    base::Time time_1_neg= base::Time::fromMicroseconds(-1);
+    base::Time time_10_neg= base::Time::fromMicroseconds(-10);
+    
+    BOOST_CHECK(time_1!=time_10);
+
+    BOOST_CHECK(time_10>time_1);
+    BOOST_CHECK(time_1<time_10);
+    BOOST_CHECK(time_1>time_1_neg);
+    BOOST_CHECK(time_1_neg>time_10_neg);
+
+    //test multiplication and equality
+    BOOST_CHECK(time_1*10==time_10);
+    BOOST_REQUIRE_EQUAL(time_1*10,time_10);
+    
+    BOOST_CHECK(time_10/10==time_1);
+    BOOST_REQUIRE_EQUAL(time_10/10,time_1);
+    
+    BOOST_CHECK(time_1_neg*(-1)==time_1);
+    BOOST_REQUIRE_EQUAL(time_1_neg*(-1),time_1);
 }
 
 BOOST_AUTO_TEST_CASE( time_multiply )

--- a/test/test_Timeout.cpp
+++ b/test/test_Timeout.cpp
@@ -1,0 +1,46 @@
+#include <boost/test/unit_test.hpp>
+#include <base/Time.hpp>
+#include <base/Timeout.hpp>
+#include <limits>
+
+using namespace base;
+
+BOOST_AUTO_TEST_SUITE(Timeout)
+
+BOOST_AUTO_TEST_CASE(constructor_test)
+{
+	base::Timeout timeout(base::Time::fromMilliseconds(0));
+	BOOST_CHECK(!timeout.elapsed());
+	base::Timeout timeout_neg(base::Time::fromMilliseconds(-1));
+	BOOST_CHECK(timeout_neg.elapsed());
+}
+
+
+BOOST_AUTO_TEST_CASE(elapsed_timeout_test)
+{
+	base::Timeout timeout(base::Time::fromMilliseconds(1));
+	BOOST_CHECK(!timeout.elapsed());
+	sleep(1);
+	BOOST_CHECK(timeout.elapsed());
+	BOOST_CHECK(timeout.elapsed(base::Time::fromMilliseconds(1)));
+}
+
+BOOST_AUTO_TEST_CASE(restart_timeout_test)
+{
+	base::Timeout timeout(base::Time::fromMilliseconds(1));
+	sleep(1);
+	timeout.restart();
+	BOOST_CHECK(!timeout.elapsed());
+}
+BOOST_AUTO_TEST_CASE(timeleft_timeout_test)
+{
+	base::Timeout timeout(base::Time::fromMilliseconds(1));
+	BOOST_CHECK(timeout.timeLeft().toMicroseconds()>0);
+	sleep(1);
+	BOOST_CHECK(timeout.timeLeft().toMicroseconds()<=0);
+	base::Timeout max_timeout(base::Time::fromMilliseconds(0));
+	BOOST_REQUIRE_EQUAL(max_timeout.timeLeft().toMicroseconds(),
+			std::numeric_limits<int64_t>::max());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When timeout is initialized with a null time, it is considered to be a maximum timeout. So timeleft should return a maximum value instead of zero.

Besides, the initilization fromMicroseconds and fromMiliseconds in base::Time was unsigned and the internal storage from time is signed. To be consistent with the documentation and with the expected behaviour of Timeout::timeleft() (return negative time after timeout is elapsed), the arguments from these methods were also changed.

Added also unit tests to cover this changes