### PR TITLE
re-add backward compatible headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,4 @@ endif()
 
 rock_standard_layout()
 
+install(DIRECTORY base DESTINATION include)

--- a/base/backward/base/actuators/commands.h
+++ b/base/backward/base/actuators/commands.h
@@ -1,0 +1,108 @@
+#ifndef BASE_ACTUATORS_COMMANDS_H
+#define BASE_ACTUATORS_COMMANDS_H
+
+#include <vector>
+#include <base/Time.hpp>
+
+namespace base {
+    namespace actuators {
+        /** \deprecated in Rock, use the PIDSettings class from the control/motor_controller package
+         *
+         * Structure holding PID values
+         *
+         * The actual meaning of those values will obviously depend on the
+         * actuator and control electronics.
+         *
+         */
+        struct PIDValues{
+            float kp;
+            float ki;
+            float kd;
+            float maxPWM;
+
+            PIDValues() : kp(0), ki(0), kd(0), maxPWM(0) {};
+        };
+
+        /** \deprecated See the documentation of Command
+         * The control mode requested for a controller output
+         *
+         */
+        enum DRIVE_MODE
+        {
+            DM_PWM = 0, //! direct duty control
+            DM_SPEED = 1, //! speed control
+            DM_POSITION = 2, //! position control
+            DM_UNINITIALIZED = 3
+        };
+
+        /** \deprecated use base::commands::Joints
+         *
+         * Synchronized set of commands for a set of actuators
+         *
+         * Since this type contains std::vector, one must preallocate it
+         * and resize the mode and target vectors accordingly before
+         * updateHook().
+         */
+        struct Command {
+            base::Time time;
+
+            std::vector<DRIVE_MODE> mode;   //! one of DM_PWM, DM_SPEED, DM_POSITION
+            std::vector<double>     target; //! speeds are in rad/s, positions in rad and PWM in [-1, 1]
+
+            void resize(int size)
+            {
+                mode.resize(size);
+                std::fill(mode.begin(), mode.end(), DM_UNINITIALIZED);
+                target.resize(size);
+                std::fill(target.begin(), target.end(), 0);
+            }
+            
+            void invert(int pos)
+	    {
+		if (mode[pos] == DM_POSITION)
+		    target[pos] = 2 * M_PI - target[pos];
+		else
+		    target[pos] *= -1;
+	    }
+        };
+
+        /** \deprecated */
+        enum ADAPTATIVE_MODE
+        {
+            PID_POSITION = 64,
+            PID_SPEED    = 128
+        };
+
+        /** \deprecated */
+        struct AdaptativeCommand {
+            double     target;
+
+            int mode; //! OR-ed set of DRIVE_MODE and ADAPTATIVE_MODE
+            PIDValues  pid_position;
+            PIDValues  pid_speed;
+
+            AdaptativeCommand()
+                : target(0), mode(DM_UNINITIALIZED) {}
+        };
+
+        /** \deprecated
+         *
+         * Synchronized set of adaptive commands for a set of actuators
+         *
+         * Since this type contains std::vector, one must preallocate it
+         * and resize the mode and target vectors accordingly before
+         * updateHook().
+         */
+        struct AdaptativeCommands {
+            base::Time time;
+            std::vector<AdaptativeCommand> commands;
+
+            void resize(int size)
+            {
+                commands.resize(size);
+            }
+        };
+    }
+}
+
+#endif

--- a/base/backward/base/actuators/status.h
+++ b/base/backward/base/actuators/status.h
@@ -1,0 +1,70 @@
+#ifndef BASE_ACTUATORS_STATUS_HH
+#define BASE_ACTUATORS_STATUS_HH
+
+#include <base/Time.hpp>
+#include <base/Float.hpp>
+#include <vector>
+
+namespace base {
+    namespace actuators {
+        /** \deprecated use base::samples::Joints instead
+         *
+         * Represents the state of a single actuator
+         *
+         * +current+ is the current reading
+         *
+         * +position+ is the position of the actuated part (i.e. motor + gear),
+         * in radians. Wether this position is absolute or relative depends on
+         * the type of encoder on the particular actuator it represents.
+         *
+         * +positionExtern+ is used in cases where an elastic coupling exists
+         * between the motor and the actuated part (for instance, the wheel). In
+         * this case, \c position is before the elasticity and \c positionExtern
+         * after
+         *
+         * +pwm+ is the current duty-cycle
+         *
+         * +error+ is a bitfield representing the actuator state.
+         */
+        struct MotorState {
+            int      current;  //! current in mA
+            double   position; //! position in radians
+            double   positionExtern; //! position of external encoder in radians
+            float    pwm;      //! duty cycle in [-1; 1]
+
+            MotorState()
+                : current(0), position(0), positionExtern(0), pwm(0) {}
+                
+	    void setInvalid()
+	    {
+		current = 0;
+		position = base::unset<double>();
+		positionExtern = base::unset<double>();
+		pwm = base::unset<float>();
+	    }
+	    
+	    void invert()
+	    {
+		pwm *= -1;
+		position *= -1;
+		positionExtern *= -1;
+	    }
+        };
+
+        /** Synchronized set of actuator states */
+        struct Status {
+            base::Time time;
+            uint64_t index;    //! index of this packet, i.e. the position of this packet since the beginning
+            std::vector<MotorState> states;
+
+            void resize(int size)
+            {
+                states.resize(size);
+            }
+        };
+    }
+}
+
+#endif
+
+

--- a/base/backward/base/actuators/vehicles.h
+++ b/base/backward/base/actuators/vehicles.h
@@ -1,0 +1,17 @@
+#ifndef BASE_TYPES_ACTUATORS_VEHICLES_HH
+#define BASE_TYPES_ACTUATORS_VEHICLES_HH
+
+namespace base {
+    namespace actuators {
+        /** Standard joint order for all 4-wheeled systems */
+        enum WHEEL4_ACTUATORS {
+            WHEEL4_REAR_LEFT  = 0,
+            WHEEL4_REAR_RIGHT = 1,
+            WHEEL4_FRONT_RIGHT = 2,
+            WHEEL4_FRONT_LEFT = 3
+        };
+    }
+}
+
+#endif
+

--- a/base/backward/base/angle.h
+++ b/base/backward/base/angle.h
@@ -1,0 +1,1 @@
+#include <base/Angle.hpp>

--- a/base/backward/base/circular_buffer.h
+++ b/base/backward/base/circular_buffer.h
@@ -1,0 +1,1 @@
+#include <base/CircularBuffer.hpp>

--- a/base/backward/base/commands/joints.h
+++ b/base/backward/base/commands/joints.h
@@ -1,0 +1,1 @@
+#include <base/commands/Joints.hpp>

--- a/base/backward/base/eigen.h
+++ b/base/backward/base/eigen.h
@@ -1,0 +1,1 @@
+#include <base/Eigen.hpp>

--- a/base/backward/base/float.h
+++ b/base/backward/base/float.h
@@ -1,0 +1,1 @@
+#include <base/Float.hpp>

--- a/base/backward/base/geometry/spline.h
+++ b/base/backward/base/geometry/spline.h
@@ -1,0 +1,1 @@
+#include <base/geometry/Spline.hpp>

--- a/base/backward/base/joint_state.h
+++ b/base/backward/base/joint_state.h
@@ -1,0 +1,1 @@
+#include <base/JointState.hpp>

--- a/base/backward/base/logging.h
+++ b/base/backward/base/logging.h
@@ -1,0 +1,2 @@
+#include <base/Logging.hpp>
+

--- a/base/backward/base/motion_command.h
+++ b/base/backward/base/motion_command.h
@@ -1,0 +1,17 @@
+#ifndef __MOTION_COMMAND__
+#define __MOTION_COMMAND__
+
+#include <base/commands/AUVMotion.hpp>
+#include <base/commands/AUVPosition.hpp>
+#include <base/commands/Motion2D.hpp>
+#include <base/commands/Speed6D.hpp>
+
+namespace base
+{
+    typedef commands::AUVMotion AUVMotionCommand;
+    typedef commands::AUVPosition AUVPositionCommand;
+    typedef commands::Motion2D MotionCommand2D;
+    typedef commands::Speed6D SpeedCommand6D;
+}
+
+#endif

--- a/base/backward/base/odometry.h
+++ b/base/backward/base/odometry.h
@@ -1,0 +1,1 @@
+#include <base/Odometry.hpp>

--- a/base/backward/base/pose.h
+++ b/base/backward/base/pose.h
@@ -1,0 +1,1 @@
+#include <base/Pose.hpp>

--- a/base/backward/base/samples/compressed_frame.h
+++ b/base/backward/base/samples/compressed_frame.h
@@ -1,0 +1,1 @@
+#include <base/samples/CompressedFrame.hpp>

--- a/base/backward/base/samples/distance_image.h
+++ b/base/backward/base/samples/distance_image.h
@@ -1,0 +1,1 @@
+#include <base/samples/DistanceImage.hpp>

--- a/base/backward/base/samples/frame.h
+++ b/base/backward/base/samples/frame.h
@@ -1,0 +1,1 @@
+#include <base/samples/Frame.hpp>

--- a/base/backward/base/samples/imu.h
+++ b/base/backward/base/samples/imu.h
@@ -1,0 +1,1 @@
+#include <base/samples/IMUSensors.hpp>

--- a/base/backward/base/samples/joints.h
+++ b/base/backward/base/samples/joints.h
@@ -1,0 +1,1 @@
+#include <base/samples/Joints.hpp>

--- a/base/backward/base/samples/laser_scan.h
+++ b/base/backward/base/samples/laser_scan.h
@@ -1,0 +1,1 @@
+#include <base/samples/LaserScan.hpp>

--- a/base/backward/base/samples/pointcloud.h
+++ b/base/backward/base/samples/pointcloud.h
@@ -1,0 +1,1 @@
+#include <base/samples/Pointcloud.hpp>

--- a/base/backward/base/samples/rigid_body_acceleration.h
+++ b/base/backward/base/samples/rigid_body_acceleration.h
@@ -1,0 +1,1 @@
+#include <base/samples/RigidBodyAcceleration.hpp>

--- a/base/backward/base/samples/rigid_body_state.h
+++ b/base/backward/base/samples/rigid_body_state.h
@@ -1,0 +1,1 @@
+#include <base/samples/RigidBodyState.hpp>

--- a/base/backward/base/samples/sonar_beam.h
+++ b/base/backward/base/samples/sonar_beam.h
@@ -1,0 +1,1 @@
+#include <base/samples/SonarBeam.hpp>

--- a/base/backward/base/samples/sonar_scan.h
+++ b/base/backward/base/samples/sonar_scan.h
@@ -1,0 +1,1 @@
+#include <base/samples/SonarScan.hpp>

--- a/base/backward/base/singleton.h
+++ b/base/backward/base/singleton.h
@@ -1,0 +1,1 @@
+#include <base/Singleton.hpp>

--- a/base/backward/base/temperature.h
+++ b/base/backward/base/temperature.h
@@ -1,0 +1,1 @@
+#include <base/Temperature.hpp>

--- a/base/backward/base/time.h
+++ b/base/backward/base/time.h
@@ -1,0 +1,1 @@
+#include <base/Time.hpp>

--- a/base/backward/base/timemark.h
+++ b/base/backward/base/timemark.h
@@ -1,0 +1,1 @@
+#include <base/TimeMark.hpp>

--- a/base/backward/base/trajectory.h
+++ b/base/backward/base/trajectory.h
@@ -1,0 +1,1 @@
+#include <base/Trajectory.hpp>

--- a/base/backward/base/waypoint.h
+++ b/base/backward/base/waypoint.h
@@ -1,0 +1,1 @@
+#include <base/Waypoint.hpp>

--- a/src/base-types.pc.in
+++ b/src/base-types.pc.in
@@ -8,6 +8,6 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Requires: @DEPS_PKGCONFIG@
 Libs: -L${libdir} -l@TARGET_NAME@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/base/backward
 
 


### PR DESCRIPTION
The last stable was still using those, so make
sure we can at least build packages from stable
with the next stable.