### PR TITLE
DistanceImage: compute the scene point after sanity checks

### DIFF
--- a/src/samples/DistanceImage.cpp
+++ b/src/samples/DistanceImage.cpp
@@ -7,12 +7,13 @@ namespace base { namespace samples {
 
 void DistanceImage::clear()
 {
-    std::fill( data.begin(), data.end(), std::numeric_limits<float>::quiet_NaN() );
+    std::fill( data.begin(), data.end(), std::numeric_limits<scalar>::quiet_NaN() );
 }
 
 Pointcloud DistanceImage::getPointCloud() const
 {
     Pointcloud pointCloud;
+    pointCloud.time = time;
     Eigen::Vector3d point;
     for(size_t y = 0; y < this->height ; ++y)
     {

--- a/src/samples/DistanceImage.hpp
+++ b/src/samples/DistanceImage.hpp
@@ -79,16 +79,15 @@ namespace samples
 	template <class Scalar_>
 	bool getScenePoint( size_t x, size_t y, Eigen::Matrix<Scalar_,3,1>& point ) const
 	{
-	    point = Eigen::Matrix<Scalar_,3,1>( (x*scale_x)+center_x, (y*scale_y)+center_y, 1.0 );
-
 	    // check bounds. x and y are always positive
-	    if( (x >= width) || (y >= height) ) 
-            return false;
+	    if( (x >= width) || (y >= height) )
+		return false;
 
 	    // only process vector if distance value is not NaN or inf
-	    const float d = data[width*y+x];
+	    const scalar d = data[width*y+x];
 	    if( boost::math::isnormal( d ) ) 
 	    {
+		point = Eigen::Matrix<Scalar_,3,1>( (x*scale_x)+center_x, (y*scale_y)+center_y, 1.0 );
 		point *= d;
 		return true;
 	    }
@@ -107,12 +106,15 @@ namespace samples
 	    if( point.z() <= 0 )
 		return false;
 
-	    x = ((point.x() / point.z()) - center_x) / scale_x;
-	    y = ((point.y() / point.z()) - center_y) / scale_y;
+	    size_t u = ((point.x() / point.z()) - center_x) / scale_x;
+	    size_t v = ((point.y() / point.z()) - center_y) / scale_y;
 
-	    // check bounds. x and y are always positive
-	    if( (x >= width) || (y >= height) ) 
-            return false;
+	    // check bounds. u and v are always positive
+	    if( (u >= width) || (v >= height) )
+		return false;
+
+	    x = u;
+	    y = v;
 
 	    return true;
 	}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -597,6 +597,57 @@ BOOST_AUTO_TEST_CASE(distance_image_test)
     BOOST_CHECK(point_cloud.points[1] == Eigen::Vector3d(0.0, -2.00, 2.00));
     BOOST_CHECK(point_cloud.points[2] == Eigen::Vector3d(-2.0, 0.00, 2.00));
     BOOST_CHECK(point_cloud.points[3] == Eigen::Vector3d(0.0, 0.00, 1.00));
+
+    /** Scene and image point projections **/
+    dimage.setSize(3,2);
+    dimage.clear();
+    dimage.data[0] = 1.0;
+    dimage.data[1] = 2.0;
+    dimage.data[2] = 0.0;
+    dimage.data[3] = std::numeric_limits<base::samples::DistanceImage::scalar>::denorm_min();
+    dimage.data[4] = std::numeric_limits<base::samples::DistanceImage::scalar>::infinity();
+    dimage.data[5] = std::numeric_limits<base::samples::DistanceImage::scalar>::quiet_NaN();
+
+    Eigen::Vector3d scene_point = Eigen::Vector3d::Zero();
+    size_t x = std::numeric_limits<size_t>::max(), y = std::numeric_limits<size_t>::max();
+    // test valid projections
+    BOOST_CHECK(dimage.getScenePoint(0,0,scene_point));
+    BOOST_CHECK(dimage.getImagePoint(scene_point,x,y));
+    BOOST_CHECK(x == 0);
+    BOOST_CHECK(y == 0);
+
+    BOOST_CHECK(dimage.getScenePoint(1,0,scene_point));
+    BOOST_CHECK(dimage.getImagePoint(scene_point,x,y));
+    BOOST_CHECK(x == 1);
+    BOOST_CHECK(y == 0);
+
+    // test invalid distacnes
+    scene_point.setZero();
+    x = std::numeric_limits<size_t>::max();
+    y = std::numeric_limits<size_t>::max();
+    BOOST_CHECK(dimage.getScenePoint(2,0,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getScenePoint(0,1,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getScenePoint(1,1,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getScenePoint(2,1,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getImagePoint(scene_point,x,y) == false);
+    BOOST_CHECK(x == std::numeric_limits<size_t>::max());
+    BOOST_CHECK(y == std::numeric_limits<size_t>::max());
+
+    // test bounds
+    BOOST_CHECK(dimage.getScenePoint(3,2,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getScenePoint(0,2,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    BOOST_CHECK(dimage.getScenePoint(3,0,scene_point) == false);
+    BOOST_CHECK(scene_point == Eigen::Vector3d::Zero());
+    scene_point = Eigen::Vector3d(1.0, 1.0, 1.0);
+    BOOST_CHECK(dimage.getImagePoint(scene_point,x,y) == false);
+    BOOST_CHECK(x == std::numeric_limits<size_t>::max());
+    BOOST_CHECK(y == std::numeric_limits<size_t>::max());
 }
 
 BOOST_AUTO_TEST_CASE(depth_map_test)


### PR DESCRIPTION
Also:
- forward time stamp to point cloud
- fixed indentation to be consistent
- extended unit tests