### PR TITLE
Make SISL optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ if(SISL_FOUND)
                Trajectory.hpp)
   set(sisl_cpp Spline.cpp
                Trajectory.cpp)
+  include_directories(${SISL_INCLUDE_DIRS})
 else()
   message(WARNING "SISL not found. Compiling without spline and trajectory support!")
 endif()
@@ -104,6 +105,8 @@ rock_library(
 )
 
 if(SISL_FOUND)
+  target_link_libraries(base-types ${SISL_LIBRARIES})
+  
   install(FILES ${CMAKE_SOURCE_DIR}/src/Spline.hpp
   	DESTINATION include/base/geometry)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,11 +4,14 @@ find_package(SISL)
 set(sisl_hpp "")
 set(sisl_cpp "")
 
+#compile without Spline and Trajectory if SISL is not found
 if(SISL_FOUND)
-  set(sisl_hpp "Spline.hpp")
-  set(sisl_cpp "Spline.cpp")
+  set(sisl_hpp Spline.hpp
+               Trajectory.hpp)
+  set(sisl_cpp Spline.cpp
+               Trajectory.cpp)
 else()
-  message(WARNING "SISL not found. Compiling without spline support!")
+  message(WARNING "SISL not found. Compiling without spline and trajectory support!")
 endif()
 
 rock_library(
@@ -26,7 +29,6 @@ rock_library(
         Time.cpp
         TimeMark.cpp
         Timeout.cpp
-        Trajectory.cpp
         TransformWithCovariance.cpp
         TwistWithCovariance.cpp
         Waypoint.cpp
@@ -67,7 +69,6 @@ rock_library(
         ${sisl_hpp}
         TimeMark.hpp
         Timeout.hpp
-        Trajectory.hpp
         TransformWithCovariance.hpp
         TwistWithCovariance.hpp
         Waypoint.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,18 @@
+
+find_package(SISL)
+
+set(sisl_hpp "")
+set(sisl_cpp "")
+
+if(SISL_FOUND)
+  set(sisl_hpp "Spline.hpp")
+  set(sisl_cpp "Spline.cpp")
+else()
+  message(WARNING "SISL not found. Compiling without spline support!")
+endif()
+
 rock_library(
-    base-types 
+    base-types
         Angle.cpp
         JointLimitRange.cpp
         JointLimits.cpp
@@ -8,7 +21,7 @@ rock_library(
         JointTransform.cpp
         Pose.cpp
         Pressure.cpp
-        Spline.cpp
+        ${sisl_cpp}
         Temperature.cpp
         Time.cpp
         TimeMark.cpp
@@ -48,10 +61,10 @@ rock_library(
         Point.hpp
         Pose.hpp
         Pressure.hpp
-        Singleton.hpp 
-        Spline.hpp
+        Singleton.hpp
         Temperature.hpp
         Time.hpp
+        ${sisl_hpp}
         TimeMark.hpp
         Timeout.hpp
         Trajectory.hpp
@@ -63,7 +76,7 @@ rock_library(
         commands/Motion2D.hpp
         commands/Speed6D.hpp
 	commands/LinearAngular6DCommand.hpp
-        logging/logging_iostream_style.h 
+        logging/logging_iostream_style.h
         logging/logging_printf_style.h
         samples/BodyState.hpp
         samples/CommandSamples.hpp
@@ -84,15 +97,15 @@ rock_library(
         samples/Wrench.hpp
         samples/Wrenches.hpp
         templates/TimeStamped.hpp
-    DEPS_CMAKE 
-        SISL
-    DEPS_PKGCONFIG 
+    DEPS_PKGCONFIG
         base-logging
         eigen3
 )
 
-install(FILES ${CMAKE_SOURCE_DIR}/src/Spline.hpp
-	DESTINATION include/base/geometry)
+if(SISL_FOUND)
+  install(FILES ${CMAKE_SOURCE_DIR}/src/Spline.hpp
+  	DESTINATION include/base/geometry)
+endif()
 
 configure_file(base-lib.pc.in ${CMAKE_BINARY_DIR}/base-lib.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/base-lib.pc DESTINATION lib/pkgconfig)


### PR DESCRIPTION
The mainfest defines sisl as optional but base-types does not compile without sisl. This PR fixes that issue.

This reduces the number of dependencies that we need to install when using base-types outside of rock. In our use case we are dependent on base types but not on Spline/Trajectory, thus we do not need the SISL dependency.

