### PR TITLE
ruby: do not display the curve length while pretty-printing SISL::Spline

### DIFF
--- a/bindings/ruby/lib/sisl/spline.rb
+++ b/bindings/ruby/lib/sisl/spline.rb
@@ -295,15 +295,13 @@ module SISL
             end
 	    
 	    def pretty_print(pp)
-		if(empty?)
+		if empty?
 		    pp.text "Curve is empty"
 		    pp.breakable		
 		else
-		    pp.text "dimensions=[#{start_point}, #{end_point}]"
+                    pp.text "start_point,end_point=[#{start_point}, #{end_point}]"
 		    pp.breakable		
-		    pp.text "length=[#{curve_length}]"
-		    pp.breakable
-		    pp.text "params=[#{start_param}, #{end_param}]"
+                    pp.text "start_param,end_param=[#{start_param}, #{end_param}]"
 		end
 	    end
 	    


### PR DESCRIPTION
This is potentially a very expensive operation (in my case,
was not done after 30s+ which is really bad in the default
pretty-printing function (i.e. can block exception display)