### PR TITLE
Fix building without qt4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,4 @@ if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/test)
     endif()
 endif()
 
-rock_find_qt4()
 rock_standard_layout()

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -1,3 +1,4 @@
+rock_find_qt4()
 rock_vizkit_plugin(base-viz
     PluginLoader.cpp Uncertainty.cpp Vizkit3DHelper.cpp
     MOC 


### PR DESCRIPTION
qt4 is an optional requirement only needed for the optional viz part of the package.
Moving it into the viz directory fixes building on systems, which don't have qt4 installed.