### PR TITLE
spline: remove wrong validity check in Spline::interpolate

### DIFF
--- a/src/Spline.cpp
+++ b/src/Spline.cpp
@@ -269,12 +269,6 @@ void SplineBase::interpolate(const vector< double >& points,
     has_curvature_max = false;
 
     unsigned int const point_count = points.size() / dimension;
-    if (!parametersIn.empty() && parametersIn.size() != point_count) {
-        throw std::invalid_argument(
-            "base::geometry::SplineBase::interpolate: "
-            "expected " + to_string(point_count) + " parameters, "
-            "but got " + to_string(parametersIn.size()));
-    }
     if (point_count == 0)
     {
         end_param = 0;

--- a/test/test_Spline.cpp
+++ b/test/test_Spline.cpp
@@ -4,9 +4,10 @@
 #include <base/geometry/Spline.hpp>
 
 
-BOOST_AUTO_TEST_SUITE(Spline)
+BOOST_AUTO_TEST_SUITE(SplineTests)
 
-using base::geometry::Spline;
+using namespace std;
+using namespace base::geometry;
 
 BOOST_AUTO_TEST_CASE(test_interpolate_with_nonempty_curve_updates_the_start_and_end_param_properly)
 {
@@ -32,13 +33,47 @@ BOOST_AUTO_TEST_CASE(test_interpolate_with_no_points_sets_the_start_and_end_to_z
     BOOST_CHECK_EQUAL(0, spline.getEndParam());
 }
 
-BOOST_AUTO_TEST_CASE(test_interpolate_with_mismatching_number_of_points_and_parameters_throws)
+BOOST_AUTO_TEST_CASE(test_interpolate_accepts_points_and_parameters)
 {
+    auto points = vector<double>{1.0, 2.0, 3.0};
+    auto parameters = vector<double>{1.0, 1.8, 2.0};
+    auto types = {
+        SplineBase::ORDINARY_POINT,
+        SplineBase::ORDINARY_POINT,
+        SplineBase::ORDINARY_POINT
+    };
+
     Spline<1> spline;
-    BOOST_CHECK_THROW(
-        spline.interpolate(std::vector<double>{1.0}, {1.0, 2.0}),
-        std::invalid_argument);
+    spline.interpolate(points, parameters, types);
+    auto p0 = spline.getPoint(1.0);
+    auto p1 = spline.getPoint(1.8);
+    auto p2 = spline.getPoint(2.0);
+    BOOST_CHECK_CLOSE(1.0, p0(0), 1e-3);
+    BOOST_CHECK_CLOSE(2.0, p1(0), 1e-3);
+    BOOST_CHECK_CLOSE(3.0, p2(0), 1e-3);
 }
+
+BOOST_AUTO_TEST_CASE(test_interpolate_accepts_derivatives_and_parameters)
+{
+    auto points = vector<double>{1.0, 0.0, 2.0, 0.0};
+    auto parameters = vector<double>{1.0, 2.0};
+    auto types = {
+        SplineBase::ORDINARY_POINT,
+        SplineBase::DERIVATIVE_TO_PRIOR,
+        SplineBase::ORDINARY_POINT,
+        SplineBase::DERIVATIVE_TO_PRIOR
+    };
+
+    Spline<1> spline;
+    spline.interpolate(points, parameters, types);
+    auto p0 = spline.getPointAndTangent(1.0);
+    auto p1 = spline.getPointAndTangent(2.0);
+    BOOST_CHECK_CLOSE(1.0, p0.first(0), 1e-3);
+    BOOST_CHECK_CLOSE(0.0, p0.second(0), 1e-3);
+    BOOST_CHECK_CLOSE(2.0, p1.first(0), 1e-3);
+    BOOST_CHECK_CLOSE(0.0, p1.second(0), 1e-3);
+}
+
 
 BOOST_AUTO_TEST_CASE(test_interpolate_takes_dimension_into_account_to_validate_the_number_of_parameters)
 {


### PR DESCRIPTION
The number of parameters must be the number of "real" points,
not just the number of points. Since the only way we could get
this number would be to scan the whole type array, just remove
the check altogether.

This fixes creating splines with parameters and derivatives