### PR TITLE
Solve issue building base/types in Ubuntu 18.04

### DIFF
--- a/src/samples/DistanceImage.hpp
+++ b/src/samples/DistanceImage.hpp
@@ -5,7 +5,9 @@
 #include <base/Eigen.hpp>
 #include "Pointcloud.hpp"
 #include <vector>
+#ifndef Q_MOC_RUN
 #include <boost/math/special_functions/fpclassify.hpp>
+#endif
 
 namespace base
 {


### PR DESCRIPTION
When building in Ubuntu 18.04, there is an error for the file DistanceImageVisualization.cpp:

``` [ 48%] Generating moc_DistanceImageVisualization.cxx
/usr/include/boost/predef/language/stdc.h:52: Parse error at "defined"
viz/CMakeFiles/base-viz.dir/build.make:62: recipe for target 'viz/moc_DistanceImageVisualization.cxx' failed
make[2]: *** [viz/moc_DistanceImageVisualization.cxx] Error 1
CMakeFiles/Makefile2:140: recipe for target 'viz/CMakeFiles/base-viz.dir/all' failed
make[1]: *** [viz/CMakeFiles/base-viz.dir/all] Error 2
```

This is due to an error processing a Boost include file with the Qt MOC tool (the Boost version has probably changed in Ubuntu 18.04).

To prevent that the problematic include file is processed by MOC, the include has been enclosed with:

```
#ifndef Q_MOC_RUN
#include <boost/math/special_functions/fpclassify.hpp>
#endif
```

This macro is defined only when running MOC.

The solution was found from a similar change in RVIZ.


