### PR TITLE
Include BoundingBox and OrientedBoundingBox types

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,19 +33,21 @@ rock_library(
         Wrench.cpp
         commands/Motion2D.cpp
         samples/BodyState.cpp
+        samples/BoundingBox.cpp
         samples/DepthMap.cpp
         samples/DistanceImage.cpp
         samples/Frame.cpp
         samples/Joints.cpp
         samples/LaserScan.cpp
-        samples/Temperature.cpp
+        samples/OrientedBoundingBox.cpp
+        samples/PoseWithCovariance.cpp
         samples/Pressure.cpp
         samples/RigidBodyAcceleration.cpp
         samples/RigidBodyState.cpp
         samples/Sonar.cpp
         samples/SonarBeam.cpp
         samples/SonarScan.cpp
-        samples/PoseWithCovariance.cpp
+        samples/Temperature.cpp
         ${OPTIONAL_CPP}
     HEADERS
         Acceleration.hpp
@@ -80,10 +82,11 @@ rock_library(
         commands/Joints.hpp
         commands/Motion2D.hpp
         commands/Speed6D.hpp
-	commands/LinearAngular6DCommand.hpp
+        commands/LinearAngular6DCommand.hpp
         logging/logging_iostream_style.h 
         logging/logging_printf_style.h
         samples/Acceleration.hpp
+        samples/BoundingBox.hpp
         samples/BodyState.hpp
         samples/CommandSamples.hpp
         samples/DepthMap.hpp
@@ -92,8 +95,8 @@ rock_library(
         samples/IMUSensors.hpp
         samples/Joints.hpp
         samples/LaserScan.hpp
+        samples/OrientedBoundingBox.hpp
         samples/Pointcloud.hpp
-        samples/Temperature.hpp
         samples/Pressure.hpp
         samples/RigidBodyAcceleration.hpp
         samples/RigidBodyState.hpp
@@ -104,9 +107,10 @@ rock_library(
         samples/SonarScan.hpp
         samples/PoseWithCovariance.hpp
         samples/Twist.hpp
+        samples/Temperature.hpp
+        templates/TimeStamped.hpp
         samples/Wrench.hpp
         samples/Wrenches.hpp
-        templates/TimeStamped.hpp
         ${OPTIONAL_HPP}
     DEPS_PKGCONFIG 
         base-logging

--- a/src/Waypoint.cpp
+++ b/src/Waypoint.cpp
@@ -1,22 +1,45 @@
+// Copyright 2020 Rock-Core
 #include "Waypoint.hpp"
 
 namespace base {
 
-Waypoint::Waypoint() : position(Position::Identity()), heading(0), tol_position(0), tol_heading(0)
-{
-    
+Waypoint::Waypoint()
+    : position(Position::Identity()),
+      heading(0),
+      tol_position(0),
+      tol_heading(0) {
 }
 
-Waypoint::Waypoint(const Vector3d& _position, double _heading, double _tol_position, double _tol_heading)
-    : position(_position), heading(_heading), tol_position(_tol_position), tol_heading(_tol_heading)
-{
-
+Waypoint::Waypoint(base::Vector3d const& position,
+                   double heading)
+    : position(position),
+      heading(heading),
+      tol_position(0),
+      tol_heading(0) {
 }
 
-Waypoint::Waypoint(const Eigen::Vector3d& _position, double _heading, double _tol_position, double _tol_heading)
-     : position(_position), heading(_heading), tol_position(_tol_position), tol_heading(_tol_heading)
-{
-
+Waypoint::Waypoint(base::Vector3d const& position,
+                   double heading,
+                   double tol_position,
+                   double tol_heading)
+    : position(position),
+      heading(heading),
+      tol_position(tol_position),
+      tol_heading(tol_heading) {
 }
 
-} //end namespace base
+Waypoint::Waypoint(Eigen::Vector3d const& position,
+                   double heading,
+                   double tol_position,
+                   double tol_heading)
+    : position(position),
+      heading(heading),
+      tol_position(tol_position),
+      tol_heading(tol_heading) {
+}
+
+bool Waypoint::hasValidPosition() const {
+    return position.allFinite();
+}
+
+}  // namespace base

--- a/src/Waypoint.hpp
+++ b/src/Waypoint.hpp
@@ -1,36 +1,64 @@
-#ifndef __BASE_WAYPOINT_HH__
-#define __BASE_WAYPOINT_HH__
+// Copyright 2020 Rock-Core
+#ifndef BASE_WAYPOINT_HH_
+#define BASE_WAYPOINT_HH_
 
-#include <base/Pose.hpp>
 #include <base/Eigen.hpp>
+#include <base/Pose.hpp>
 
-namespace base
-{
+namespace base {
+/**
+ * Representation of a position associated with a heading in radians.
+ */
+struct Waypoint {
     /**
-     * Representation for a pose
+     * Position is initialized with identity vector (1, 0, 0).
+     * All the other values are initialized with zeros.
      */
-    struct Waypoint
-    {
-        base::Vector3d position;
-        //heading in radians
-        double heading;
+    Waypoint();
 
-        //tollerance of the position in m
-        double tol_position;
-        //tollerance of the heading in rad
-        double tol_heading;
+    /* The default values are initialized with zeros. */
+    explicit Waypoint(base::Vector3d const &position,
+                      double heading = 0);
 
-        // default: initializing with identity and zero
-        Waypoint();
-            
-        // use base::Vector3d
-        Waypoint(base::Vector3d const &_position, double _heading,
-                 double _tol_position, double _tol_heading);
-        // convenience: same for Eigen::Vector3d
-        Waypoint(Eigen::Vector3d const &_position, double _heading,
-                 double _tol_position, double _tol_heading);
-    };
+    /* use Vector3d */
+    Waypoint(base::Vector3d const &position,
+             double heading,
+             double tol_position,
+             double tol_heading);
+
+    /* convenience: same for Eigen::Vector3d */
+    Waypoint(Eigen::Vector3d const &position,
+             double heading,
+             double tol_position,
+             double tol_heading);
+
+    /* Three-dimensional position (x, y, z) */
+    base::Vector3d position;
+
+    /* heading in radians */
+    double heading;
+
+    /* tollerance of the position in meters */
+    double tol_position;
+
+    /* tollerance of the heading in radians */
+    double tol_heading;
+
+    bool hasValidPosition() const;
+};
+
+/**
+ * Returns an waypoint object initialized with unknown values.
+ */
+template <>
+inline Waypoint unknown() {
+    return Waypoint(
+        base::Vector3d(base::Vector3d::Ones() * unknown<double>()),
+        unknown<double>(),
+        unknown<double>(),
+        unknown<double>());
 }
 
-#endif
+}  // namespace base
 
+#endif

--- a/src/samples/BoundingBox.cpp
+++ b/src/samples/BoundingBox.cpp
@@ -1,0 +1,49 @@
+// Copyright 2020 Rock-Core
+#include "BoundingBox.hpp"
+
+namespace base {
+namespace samples {
+
+BoundingBox::BoundingBox(const Time& time,
+                         const Vector3d& position,
+                         const Vector3d& dimension) {
+    initBoundingBox(time, position, dimension);
+}
+
+void BoundingBox::initBoundingBox(const Time& time,
+                                  const Vector3d& position,
+                                  const Vector3d& dimension) {
+    this->time = time;
+    this->position = position;
+    this->dimension = dimension;
+    this->cov_position = Matrix3d::Ones() * unknown<double>();
+    this->cov_dimension = Matrix3d::Ones() * unknown<double>();
+}
+
+bool BoundingBox::hasValidBoundingBox() const {
+    return hasValidPosition() &&
+           hasValidDimension();
+}
+
+bool BoundingBox::hasValidPosition() const {
+    return position.allFinite();
+}
+
+bool BoundingBox::hasValidDimension() const {
+    return dimension.allFinite();
+}
+
+bool BoundingBox::hasValidCovariance() const {
+    return hasValidCovPosition() && hasValidCovDimension();
+}
+
+bool BoundingBox::hasValidCovPosition() const {
+    return cov_position.allFinite();
+}
+
+bool BoundingBox::hasValidCovDimension() const {
+    return cov_dimension.allFinite();
+}
+
+}  // namespace samples
+}  // namespace base

--- a/src/samples/BoundingBox.hpp
+++ b/src/samples/BoundingBox.hpp
@@ -1,0 +1,84 @@
+// Copyright 2020 Rock-Core
+#ifndef BASE_SAMPLES_BOUNDINGBOX_HPP_
+#define BASE_SAMPLES_BOUNDINGBOX_HPP_
+
+#include <base/Eigen.hpp>
+#include <base/Float.hpp>
+#include <base/Time.hpp>
+
+namespace base {
+namespace samples {
+/** Axis-aligned Bounding Box (ABB) representation
+ *
+ * The data structure is used to represent the three-dimensional Axis-aligned
+ * Bounding Box (x, y, z, w, h, l) with the associated uncertainty, where x, y
+ * and z are the center position of the bounding box and w, h and l are the
+ * bounding box width, height and length.
+ */
+struct BoundingBox {
+    explicit BoundingBox(
+        const Time& time = Time(),
+        const Vector3d& position = Vector3d::Ones() * unknown<double>(),
+        const Vector3d& dimension = Vector3d::Ones() * unknown<double>());
+
+    /**
+     * Initialize the structure fields.
+     */
+    void initBoundingBox(const Time& time,
+                         const Vector3d& position,
+                         const Vector3d& dimension);
+
+    /**
+     * Returns true if the position and the dimension of the bounding box are
+     * different of NaN.
+     */
+    bool hasValidBoundingBox() const;
+
+    /**
+     * Returns true if the position of the bounding box is different of NaN.
+     */
+    bool hasValidPosition() const;
+
+    /**
+     * Returns true if the dimension of the bounding box is different of NaN.
+     */
+    bool hasValidDimension() const;
+
+    /**
+     * Returns true if the covariance associated to the position and the
+     * dimension of the bounding box are different of NaN.
+     */
+    bool hasValidCovariance() const;
+
+    /**
+     * Returns true if the covariance associated to the position is different
+     * of NaN.
+     */
+    bool hasValidCovPosition() const;
+
+    /**
+     * Returns true if the covariance associated to the dimension is different
+     * of NaN.
+     */
+    bool hasValidCovDimension() const;
+
+    /* The sample timestamp. */
+    Time time;
+
+    /* 3D center (x, y, z) position of the bounding box . */
+    Vector3d position;
+
+    /* 3D dimension (width, height, length) of the bounding box. */
+    Vector3d dimension;
+
+    /* The position uncertainty represented as a 3x3 matrix. */
+    Matrix3d cov_position;
+
+    /* The dimension uncertainty represented as a 3x3 matrix. */
+    Matrix3d cov_dimension;
+};
+
+}  // namespace samples
+}  // namespace base
+
+#endif  // BASE_SAMPLES_ORIENTEDBOUDINGBOX_HPP_

--- a/src/samples/OrientedBoundingBox.cpp
+++ b/src/samples/OrientedBoundingBox.cpp
@@ -1,0 +1,40 @@
+// Copyright 2020 Rock-Core
+#include "OrientedBoundingBox.hpp"
+
+namespace base {
+namespace samples {
+
+OrientedBoundingBox::OrientedBoundingBox(const Time& time,
+                                         const Vector3d& position,
+                                         const Vector3d& dimension,
+                                         const Orientation& orientation) {
+    initOrientedBoundingBox(time, position, dimension, orientation);
+}
+
+void OrientedBoundingBox::initOrientedBoundingBox(const Time& time,
+                                                  const Vector3d& position,
+                                                  const Vector3d& dimension,
+                                                  const Orientation& orientation) {
+    initBoundingBox(time, position, dimension);
+    this->orientation = orientation;
+    this->cov_orientation = Matrix3d::Ones() * unknown<double>();
+}
+
+bool OrientedBoundingBox::hasValidBoundingBox() const {
+    return BoundingBox::hasValidBoundingBox() && hasValidOrientation();
+}
+
+bool OrientedBoundingBox::hasValidOrientation() const {
+    return orientation.toRotationMatrix().allFinite();
+}
+
+bool OrientedBoundingBox::hasValidCovariance() const {
+    return BoundingBox::hasValidCovariance() && hasValidCovOrientation();
+}
+
+bool OrientedBoundingBox::hasValidCovOrientation() const {
+    return cov_orientation.allFinite();
+}
+
+}  // namespace samples
+}  // namespace base

--- a/src/samples/OrientedBoundingBox.hpp
+++ b/src/samples/OrientedBoundingBox.hpp
@@ -1,0 +1,67 @@
+// Copyright 2020 Rock-Core
+#ifndef BASE_SAMPLES_ORIENTEDBOUNDINGBOX_HPP_
+#define BASE_SAMPLES_ORIENTEDBOUNDINGBOX_HPP_
+
+#include <base/Pose.hpp>
+#include <base/samples/BoundingBox.hpp>
+
+namespace base {
+namespace samples {
+/** Oriented Bounding Box (OBB) representation.
+ *
+ * The data structure represents a three-dimensional Oriented Bounding Box
+ * (OBB) with the associated uncertainty. It is derived from
+ * base::samples::BoundingBox and includes the rotation information with
+ * respect to the bounding box center position.
+ *
+ * @see base::samples::BoundingBox
+ */
+struct OrientedBoundingBox : public BoundingBox {
+    explicit OrientedBoundingBox(
+        const Time& = Time(),
+        const Vector3d& position = Vector3d::Ones() * unknown<double>(),
+        const Vector3d& dimension = Vector3d::Ones() * unknown<double>(),
+        const Orientation& orientation = Orientation(
+            Vector4d::Ones() * unknown<double>()));
+
+    /**
+     * Initialize the structure fields with Vector4d to represent the
+     * orientation.
+     */
+    void initOrientedBoundingBox(const Time& time,
+                                 const Vector3d& position,
+                                 const Vector3d& dimension,
+                                 const Orientation& orientation);
+
+    /**
+     * Returns true if the position, dimension and orientation of the bounding
+     * box are different of NaN.
+     */
+    bool hasValidBoundingBox() const;
+    /**
+     * Returns true if the orientation of the bounding box is different of NaN.
+     */
+    bool hasValidOrientation() const;
+    /**
+     * Returns true if the covariance associated to the position, dimension and
+     * orientation of the bounding box are different of NaN.
+     */
+    bool hasValidCovariance() const;
+
+    /**
+     * Returns true if the covariance associated to the orientation is different
+     * of NaN.
+     */
+    bool hasValidCovOrientation() const;
+
+    /* Bounding box rotation with respect its center position. */
+    Orientation orientation;
+
+    /* The orientation uncertainty represented as a 3x3 matrix. */
+    Matrix3d cov_orientation;
+};
+
+}  // namespace samples
+}  // namespace base
+
+#endif  // BASE_SAMPLES_ORIENTEDBOUNDINGBOX_HPP_

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1373,6 +1373,36 @@ BOOST_AUTO_TEST_CASE( oriented_bounding_box )
     BOOST_CHECK(obb.hasValidCovOrientation() == true);
 }
 
+BOOST_AUTO_TEST_CASE( waypoint )
+{
+    base::Waypoint wp;
+    BOOST_CHECK(wp.hasValidPosition() == true);
+    BOOST_CHECK(wp.position == base::Vector3d(1, 0, 0));
+    BOOST_CHECK(wp.heading == 0);
+    BOOST_CHECK(wp.tol_position == 0);
+    BOOST_CHECK(wp.tol_heading == 0);
+
+    wp = base::Waypoint(base::Vector3d(1, 1, 1), M_PI);
+    BOOST_CHECK(wp.hasValidPosition() == true);
+    BOOST_CHECK(wp.position == base::Vector3d(1, 1, 1));
+    BOOST_CHECK(wp.heading == M_PI);
+    BOOST_CHECK(wp.tol_position == 0);
+    BOOST_CHECK(wp.tol_heading == 0);
+
+    wp = base::Waypoint(base::Vector3d(1, 1, 1), M_PI_2, 1, 2);
+    BOOST_CHECK(wp.position == base::Vector3d(1, 1, 1));
+    BOOST_CHECK(wp.hasValidPosition() == true);
+    BOOST_CHECK(wp.heading == M_PI_2);
+    BOOST_CHECK(wp.tol_position == 1);
+    BOOST_CHECK(wp.tol_heading == 2);
+
+    wp = base::unknown<base::Waypoint>();
+    BOOST_CHECK(wp.hasValidPosition() == false);
+    BOOST_CHECK(base::isUnknown(wp.heading) == true);
+    BOOST_CHECK(base::isUnknown(wp.tol_position) == true);
+    BOOST_CHECK(base::isUnknown(wp.tol_heading) == true);
+}
+
 #ifdef SISL_FOUND
 #include <base/geometry/spline.h>
 BOOST_AUTO_TEST_CASE( spline_to_points )

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -9,27 +9,29 @@
 #include <base/Eigen.hpp>
 #include <base/Float.hpp>
 #include <base/JointState.hpp>
-#include <base/NamedVector.hpp>
 #include <base/JointLimitRange.hpp>
 #include <base/JointLimits.hpp>
 #include <base/JointsTrajectory.hpp>
+#include <base/NamedVector.hpp>
 #include <base/Point.hpp>
 #include <base/Pose.hpp>
 #include <base/Pressure.hpp>
 //#include <base/samples/CompressedFrame.hpp>
+#include <base/samples/BodyState.hpp>
+#include <base/samples/BoundingBox.hpp>
+#include <base/samples/DepthMap.hpp>
 #include <base/samples/DistanceImage.hpp>
 #include <base/samples/Frame.hpp>
 #include <base/samples/IMUSensors.hpp>
 #include <base/samples/Joints.hpp>
 #include <base/samples/LaserScan.hpp>
+#include <base/samples/OrientedBoundingBox.hpp>
 #include <base/samples/Pointcloud.hpp>
 #include <base/samples/Pressure.hpp>
 #include <base/samples/RigidBodyAcceleration.hpp>
 #include <base/samples/RigidBodyState.hpp>
-#include <base/samples/BodyState.hpp>
 #include <base/samples/SonarBeam.hpp>
 #include <base/samples/SonarScan.hpp>
-#include <base/samples/DepthMap.hpp>
 #include <base/TransformWithCovariance.hpp>
 #include <base/samples/Sonar.hpp>
 #include <base/samples/PoseWithCovariance.hpp>
@@ -1262,6 +1264,113 @@ BOOST_AUTO_TEST_CASE( pose_with_covariance )
 
     BOOST_CHECK( sensor_in_body.getTransform().matrix().isApprox( sensor_in_body_r.getTransform().matrix(), 1e-12 ) );
     BOOST_CHECK( sensor_in_body.getCovariance().isApprox( sensor_in_body_r.getCovariance(), 1e-12 ) );
+}
+
+BOOST_AUTO_TEST_CASE( bounding_box )
+{
+    base::samples::BoundingBox bb;
+
+    BOOST_CHECK(bb.hasValidBoundingBox() == false);
+    BOOST_CHECK(bb.hasValidCovariance() == false);
+
+    bb = base::samples::BoundingBox(base::Time::now(),
+                                    base::Vector3d(0, 0, 0));
+
+    BOOST_CHECK(bb.hasValidBoundingBox() == false);
+    BOOST_CHECK(bb.hasValidPosition() == true);
+    BOOST_CHECK(bb.hasValidDimension() == false);
+
+    bb = base::samples::BoundingBox(base::Time::now(),
+                                    base::Vector3d(0, 0, 0),
+                                    base::Vector3d(0, 0, 0));
+
+    BOOST_CHECK(bb.hasValidBoundingBox() == true);
+    BOOST_CHECK(bb.hasValidPosition() == true);
+    BOOST_CHECK(bb.hasValidDimension() == true);
+
+    bb.cov_position = base::Matrix3d::Zero();
+
+    BOOST_CHECK(bb.hasValidCovariance() == false);
+    BOOST_CHECK(bb.hasValidCovPosition() == true);
+    BOOST_CHECK(bb.hasValidCovDimension() == false);
+
+    bb.cov_dimension = base::Matrix3d::Zero();
+
+    BOOST_CHECK(bb.hasValidCovariance() == true);
+    BOOST_CHECK(bb.hasValidCovPosition() == true);
+    BOOST_CHECK(bb.hasValidCovDimension() == true);
+}
+
+BOOST_AUTO_TEST_CASE( oriented_bounding_box )
+{
+    base::samples::OrientedBoundingBox obb;
+    BOOST_CHECK(obb.hasValidBoundingBox() == false);
+    BOOST_CHECK(obb.hasValidCovariance() == false);
+    BOOST_CHECK(obb.hasValidOrientation() == false);
+
+    obb = base::samples::OrientedBoundingBox(base::Time::now(),
+                                             base::Vector3d(0, 0, 0));
+
+    BOOST_CHECK(obb.hasValidBoundingBox() == false);
+    BOOST_CHECK(obb.hasValidPosition() == true);
+    BOOST_CHECK(obb.hasValidDimension() == false);
+    BOOST_CHECK(obb.hasValidOrientation() == false);
+
+    obb = base::samples::OrientedBoundingBox(base::Time::now(),
+                                             base::Vector3d(0, 0, 0),
+                                             base::Vector3d(0, 0, 0));
+
+    BOOST_CHECK(obb.hasValidBoundingBox() == false);
+    BOOST_CHECK(obb.hasValidPosition() == true);
+    BOOST_CHECK(obb.hasValidDimension() == true);
+    BOOST_CHECK(obb.hasValidOrientation() == false);
+
+    obb = base::samples::OrientedBoundingBox(base::Time::now(),
+                                             base::Vector3d(0, 0, 0),
+                                             base::Vector3d(0, 0, 0),
+                                             base::Orientation(0, 0, 0, 0));
+
+    BOOST_CHECK(obb.hasValidBoundingBox() == true);
+    BOOST_CHECK(obb.hasValidPosition() == true);
+    BOOST_CHECK(obb.hasValidDimension() == true);
+    BOOST_CHECK(obb.hasValidOrientation() == true);
+
+    obb = base::samples::OrientedBoundingBox(base::Time::now(),
+                                             base::Vector3d(1, 1, 1),
+                                             base::Vector3d(1, 1, 1),
+                                             base::Quaterniond::Identity());
+
+
+    BOOST_CHECK(obb.position == base::Vector3d(1, 1, 1));
+    BOOST_CHECK(obb.dimension == base::Vector3d(1, 1, 1));
+    BOOST_CHECK(obb.orientation.w() == 1);
+    BOOST_CHECK(obb.orientation.vec() == base::Vector3d(0, 0, 0));
+
+    BOOST_CHECK(obb.hasValidCovariance() == false);
+    BOOST_CHECK(obb.hasValidCovPosition() == false);
+    BOOST_CHECK(obb.hasValidCovDimension() == false);
+    BOOST_CHECK(obb.hasValidCovOrientation() == false);
+
+    obb.cov_position = base::Matrix3d::Zero();
+
+    BOOST_CHECK(obb.hasValidCovariance() == false);
+    BOOST_CHECK(obb.hasValidCovPosition() == true);
+    BOOST_CHECK(obb.hasValidCovDimension() == false);
+    BOOST_CHECK(obb.hasValidCovOrientation() == false);
+
+    obb.cov_dimension = base::Matrix3d::Zero();
+
+    BOOST_CHECK(obb.hasValidCovariance() == false);
+    BOOST_CHECK(obb.hasValidCovPosition() == true);
+    BOOST_CHECK(obb.hasValidCovDimension() == true);
+    BOOST_CHECK(obb.hasValidCovOrientation() == false);
+
+    obb.cov_orientation = base::Matrix3d::Zero();
+
+    BOOST_CHECK(obb.hasValidCovariance() == true);
+    BOOST_CHECK(obb.hasValidCovPosition() == true);
+    BOOST_CHECK(obb.hasValidCovDimension() == true);
+    BOOST_CHECK(obb.hasValidCovOrientation() == true);
 }
 
 #ifdef SISL_FOUND


### PR DESCRIPTION
This PR includes two data types to represent axis-aligned and oriented bounding boxes with their uncertainty associated. These two data types could be used on object recognition applications.