### PR TITLE
ruby: fix spurious test failures

### DIFF
--- a/bindings/ruby/ext/base_types_ruby/Eigen.cpp
+++ b/bindings/ruby/ext/base_types_ruby/Eigen.cpp
@@ -43,6 +43,8 @@ struct Vector3
     Vector3* normalize() const { return new Vector3(v->normalized()); }
     void normalizeBang() const { v->normalize(); }
 
+    void zero() { v->setZero(); }
+
     double get(int i) const { return (*v)[i]; }
     void set(int i, double value) { (*v)[i] = value; }
 
@@ -71,7 +73,7 @@ struct Vector3
 struct VectorX {
 
     VectorXd* v;
-    
+
     VectorX()
         : v(new VectorXd()) {}
     VectorX(VectorX const& v)
@@ -82,7 +84,9 @@ struct VectorX {
         : v(new VectorXd(_v)) {}
     ~VectorX()
     { delete v; }
-    
+
+    void zero() { v->setZero(); }
+
     void resize(int n) { v->resize(n); }
     void conservativeResize(int n) { v->conservativeResize(n); }
 
@@ -102,7 +106,7 @@ struct VectorX {
 
     VectorX* operator / (double scalar) const
     { return new VectorX(*v / scalar); }
-    
+
     VectorX* negate() const
     { return new VectorX(-*v); }
 
@@ -131,6 +135,9 @@ struct Matrix4
 
     ~Matrix4()
     { delete mx; }
+
+    void zero() { mx->setZero(); }
+    void identity() { mx->setIdentity(); }
 
     double norm() const { return mx->norm(); }
 
@@ -203,9 +210,12 @@ struct MatrixX {
     unsigned int cols() const { return m->cols(); }
     unsigned int size() const { return m->size(); }
 
+    void identity() { m->setIdentity(); }
+    void zero() { m->setZero(); }
+
     double get(int i, int j ) const { return (*m)(i,j); }
     void set(int i, int j, double value) { (*m)(i,j) = value; }
-    
+
     VectorX* getRow(int i) const { return new VectorX(m->row(i)); }
     void setRow(int i, const VectorX& v) { m->row(i) = *(v.v); }
 
@@ -226,13 +236,13 @@ struct MatrixX {
 
     MatrixX* negate() const
     { return new MatrixX(-*m); }
-    
+
     MatrixX* scale (double scalar) const
     { return new MatrixX(*m * scalar); }
 
     VectorX* dotV (VectorX const& other) const
     { return new VectorX(*m * *other.v); }
-    
+
     MatrixX* dotM (MatrixX const& other) const
     { return new MatrixX(*m * (*other.m)); }
 
@@ -284,7 +294,7 @@ struct Quaternion
     void normalizeBang()
     { q->normalize(); }
     Quaternion* normalize() const
-    { 
+    {
         Quaterniond q = *this->q;
         q.normalize();
         return new Quaternion(q);
@@ -296,7 +306,7 @@ struct Quaternion
 
     void fromAngleAxis(double angle, Vector3 const& axis)
     {
-	*(this->q) = 
+	*(this->q) =
             Eigen::AngleAxisd(angle, *axis.v);
     }
 
@@ -310,7 +320,7 @@ struct Quaternion
 
     void fromMatrix(MatrixX const& matrix)
     {
-	*(this->q) = 
+	*(this->q) =
             Quaterniond(Eigen::Matrix3d(*matrix.m));
     }
 
@@ -514,6 +524,7 @@ void Init_eigen_ext()
                Arg("y") = static_cast<double>(0),
                Arg("z") = static_cast<double>(0)))
        .define_method("__equal__",  &Vector3::operator ==)
+       .define_method("zero",  &Vector3::zero)
        .define_method("norm",  &Vector3::norm)
        .define_method("normalize!",  &Vector3::normalizeBang)
        .define_method("normalize",  &Vector3::normalize)
@@ -579,6 +590,7 @@ void Init_eigen_ext()
                (Arg("rows") = static_cast<int>(0)))
        .define_method("resize", &VectorX::resize)
        .define_method("__equal__",  &VectorX::operator ==)
+       .define_method("zero",  &VectorX::zero)
        .define_method("norm",  &VectorX::norm)
        .define_method("normalize!",  &VectorX::normalizeBang)
        .define_method("normalize",  &VectorX::normalize)
@@ -597,6 +609,8 @@ void Init_eigen_ext()
        .define_constructor(Constructor<Matrix4>())
        .define_method("__equal__",  &Matrix4::operator ==)
        .define_method("T", &Matrix4::transpose)
+       .define_method("zero",  &Matrix4::zero)
+       .define_method("identity",  &Matrix4::identity)
        .define_method("norm",  &Matrix4::norm)
        .define_method("rows", &Matrix4::rows)
        .define_method("cols", &Matrix4::cols)
@@ -625,6 +639,8 @@ void Init_eigen_ext()
        .define_method("resize", &MatrixX::resize)
        .define_method("__equal__",  &MatrixX::operator ==)
        .define_method("T", &MatrixX::transpose)
+       .define_method("zero",  &MatrixX::zero)
+       .define_method("identity", &MatrixX::identity)
        .define_method("norm",  &MatrixX::norm)
        .define_method("rows", &MatrixX::rows)
        .define_method("cols", &MatrixX::cols)

--- a/bindings/ruby/lib/eigen.rb
+++ b/bindings/ruby/lib/eigen.rb
@@ -84,6 +84,11 @@ module Eigen
         end
 
         ##
+        # :method: zero
+        #
+        # Resets all values to zero
+
+        ##
         # :method: ==
 
         ##
@@ -144,12 +149,12 @@ module Eigen
 
         ##
         # :method: normalize!
-        # 
+        #
         # Makes this vector unit-length
 
         ##
         # :method: normalize
-        # 
+        #
         # Returns a vector that has the same direction than +self+ but unit
         # length
 
@@ -198,7 +203,7 @@ module Eigen
 	    self.Identity
         end
 
-        # Creates a quaternion from an angle and axis description 
+        # Creates a quaternion from an angle and axis description
         def self.from_angle_axis(*args)
                 q = new(1, 0, 0, 0)
             q.from_angle_axis(*args)
@@ -364,19 +369,19 @@ module Eigen
 
         ##
         # :method: normalize!
-        # 
+        #
         # Normalizes this quaternion
 
         ##
         # :method: normalize
-        # 
+        #
         # Returns a quaternion that is a normalized version of +self+
 
         ##
         # :method: approx?
         # :call-seq:
         #   approx?(q, tolerance)
-        # 
+        #
         # Returns true if +self+ and +q+ do not differ from more than
         # +tolerance+. The comparison is done on a coordinate basis.
 
@@ -384,7 +389,7 @@ module Eigen
         # :method: to_euler
         # :call-seq:
         #    to_euler => Eigen::Vector3(a0, a1, a2)
-        # 
+        #
         # Decomposes this quaternion in euler angles so that +self+ can be
         # obtained by applying the following rotations in order:
         #
@@ -394,7 +399,7 @@ module Eigen
         #
         #   assuming angles in range of: a0:(-pi,pi), a1:(-pi/2,pi/2), a2:(-pi/2,pi/2)
         #
-        # note that 
+        # note that
         #
         #   self == Quaternion.from_euler(to_euler, axis0, axis1, axis2)
 
@@ -402,7 +407,7 @@ module Eigen
         # :method: from_euler
         # :call-seq:
         #    from_euler(Eigen::Vector3(a0, a1, a2), axis0, axis1, axis2)
-        # 
+        #
         # Resets this quaternion so that it represents the rotation obtained by
         # applying the following rotations in order:
         #
@@ -410,11 +415,11 @@ module Eigen
         #   rotation of a1 around axis1
         #   rotation of a0 around axis0
         #
-        # note that 
+        # note that
         #
         #   self == Quaternion.from_euler(to_euler, axis0, axis1, axis2)
 
-        ## 
+        ##
         # :method: inverse
         # :call-seq:
         #   inverse => quaternion
@@ -524,7 +529,7 @@ module Eigen
         end
 
         # Returns the array value in a vector
-        def to_a()
+        def to_a
             a = []
             for i in 0..size()-1
                     a << self[i]
@@ -544,6 +549,18 @@ module Eigen
                 self[i] = array[i]
             end
         end
+
+        # Create a zeroed-out vector
+        def self.Zero(size)
+            v = new(size)
+            v.zero
+            v
+        end
+
+        ##
+        # :method: zero
+        #
+        # Resets all values to zero
 
         def ==(v)
             v.kind_of?(self.class) &&
@@ -578,7 +595,21 @@ module Eigen
             m
         end
 
-        # Returns the array value in a vector 
+        # Builds a rows x cols zeroed-out matrix
+        def self.Zero
+            m = new
+            m.zero
+            m
+        end
+
+        # Builds a rows x cols identity matrix
+        def self.Identity
+            m = new
+            m.identity
+            m
+        end
+
+        # Returns the array value in a vector
         def to_a(column_major=true)
             a = []
             if column_major
@@ -629,6 +660,16 @@ module Eigen
             str
         end
 
+        ##
+        # :method: zero
+        #
+        # Resets all values to zero
+
+        ##
+        # :method: identity
+        #
+        # Resets the matrix to identity
+
         def _dump(level) # :nodoc:
             Marshal.dump({'rows' => rows, 'cols' => cols, 'data' => to_a})
         end
@@ -653,7 +694,21 @@ module Eigen
             m
         end
 
-        # Returns the array value in a vector 
+        # Builds a rows x cols zeroed-out matrix
+        def self.Zero(rows, cols)
+            m = new(rows, cols)
+            m.zero
+            m
+        end
+
+        # Builds a rows x cols identity matrix
+        def self.Identity(rows, cols)
+            m = new(rows, cols)
+            m.identity
+            m
+        end
+
+        # Returns the array value in a vector
         def to_a(column_major=true)
             a = []
             if column_major
@@ -721,6 +776,16 @@ module Eigen
             str += ")"
             str
         end
+
+        ##
+        # :method: zero
+        #
+        # Resets all values to zero
+
+        ##
+        # :method: identity
+        #
+        # Resets the matrix to identity
 
         def _dump(level) # :nodoc:
             Marshal.dump({'rows' => rows, 'cols' => cols, 'data' => to_a})

--- a/bindings/ruby/test/test_matrix4.rb
+++ b/bindings/ruby/test/test_matrix4.rb
@@ -1,0 +1,42 @@
+require 'minitest/autorun'
+require 'eigen'
+
+class TC_Eigen_Matrix4 < Minitest::Test
+    def test_new_zero
+        m = Eigen::Matrix4.Zero
+        4.times do |i|
+            4.times do |j|
+                assert_equal 0, m[i, j]
+            end
+        end
+    end
+
+    def test_zero
+        m = Eigen::Matrix4.new
+        m.zero
+        4.times do |i|
+            4.times do |j|
+                assert_equal 0, m[i, j]
+            end
+        end
+    end
+
+    def test_new_identity
+        m = Eigen::Matrix4.Identity
+        4.times do |i|
+            4.times do |j|
+                assert_equal((i == j ? 1 : 0), m[i, j])
+            end
+        end
+    end
+
+    def test_identity
+        m = Eigen::Matrix4.new
+        m.identity
+        4.times do |i|
+            4.times do |j|
+                assert_equal((i == j ? 1 : 0), m[i, j])
+            end
+        end
+    end
+end

--- a/bindings/ruby/test/test_matrixx.rb
+++ b/bindings/ruby/test/test_matrixx.rb
@@ -137,7 +137,7 @@ class TC_Eigen_MatrixX < Minitest::Test
     end
 
     def test_dotV
-        m = Eigen::MatrixX.new(4, 4)
+        m = Eigen::MatrixX.Zero(4, 4)
         4.times { |i| m[i, i] = i + 1 }
         a = Eigen::VectorX.from_a([1, 2, 3, 4])
         b = m.dotV(a)
@@ -148,8 +148,8 @@ class TC_Eigen_MatrixX < Minitest::Test
     end
 
     def test_jacobisvd
-        m = Eigen::MatrixX.new(7,7)
-        7.times { |i| m[i,i] = i + 1 }
+        m = Eigen::MatrixX.Zero(7, 7)
+        7.times { |i| m[i, i] = i + 1 }
         solver = m.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV)
         b = Eigen::VectorX.from_a([1, 2, 3, 4, 5, 6, 7])
         a = solver.solve(b)
@@ -157,4 +157,3 @@ class TC_Eigen_MatrixX < Minitest::Test
         assert m.dotV(a).approx?(b)
     end
 end
-

--- a/bindings/ruby/test/test_matrixx.rb
+++ b/bindings/ruby/test/test_matrixx.rb
@@ -9,9 +9,42 @@ class TC_Eigen_MatrixX < Minitest::Test
         assert_equal(m.size, 6)
     end
 
-    def test_base_vector
-        v = Eigen::VectorX.new(10)
-        assert_equal(v.size, 10)
+    def test_new_zero
+        m = Eigen::MatrixX.Zero(2, 2)
+        2.times do |i|
+            2.times do |j|
+                assert_equal 0, m[i, j]
+            end
+        end
+    end
+
+    def test_zero
+        m = Eigen::MatrixX.new(2, 2)
+        m.zero
+        2.times do |i|
+            2.times do |j|
+                assert_equal 0, m[i, j]
+            end
+        end
+    end
+
+    def test_new_identity
+        m = Eigen::MatrixX.Identity(2, 2)
+        2.times do |i|
+            2.times do |j|
+                assert_equal((i == j ? 1 : 0), m[i, j])
+            end
+        end
+    end
+
+    def test_identity
+        m = Eigen::MatrixX.new(2, 2)
+        m.identity
+        2.times do |i|
+            2.times do |j|
+                assert_equal((i == j ? 1 : 0), m[i, j])
+            end
+        end
     end
 
     def test_set

--- a/bindings/ruby/test/test_vector3.rb
+++ b/bindings/ruby/test/test_vector3.rb
@@ -9,6 +9,14 @@ class TC_Eigen_Vector3 < Minitest::Test
         assert_equal(3, v.z)
     end
 
+    def test_zero
+        v = Eigen::Vector3.new(1, 2, 3)
+        v.zero
+        assert_equal(0, v.x)
+        assert_equal(0, v.y)
+        assert_equal(0, v.z)
+    end
+
     def test_add
         v0 = Eigen::Vector3.new(1, 2, 3)
         v1 = Eigen::Vector3.new(-1, -2, -3)

--- a/bindings/ruby/test/test_vectorx.rb
+++ b/bindings/ruby/test/test_vectorx.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'eigen'
+
+class TC_Eigen_VectorX < Minitest::Test
+    def test_new
+        v = Eigen::VectorX.new(10)
+        assert_equal(v.size, 10)
+    end
+
+    def test_from_a
+        v = Eigen::VectorX.new(4)
+        v.from_a([-3.1,-4.2, 5.3, 6.4])
+        assert_equal([-3.1,-4.2, 5.3, 6.4], v.to_a)
+    end
+
+    def test_new_zero
+        v = Eigen::VectorX.Zero(4)
+        assert_equal([0, 0, 0, 0], v.to_a)
+    end
+
+    def test_zero
+        v = Eigen::VectorX.new(4)
+        v.from_a([-3.1,-4.2, 5.3, 6.4])
+        v.zero
+        assert_equal([0, 0, 0, 0], v.to_a)
+    end
+end


### PR DESCRIPTION
Two tests were not zeroing-out their matrix/vector while it was needed. Add the definition of `#zero` and `.Zero` for all types where it makes sense, and fix the tests.