### PR TITLE
remove dependency of the typelib types on the base typekit

### DIFF
--- a/bindings/ruby/test/typelib/base.tlb
+++ b/bindings/ruby/test/typelib/base.tlb
@@ -1,0 +1,3127 @@
+<?xml version='1.0'?>
+<typelib>
+  <opaque includes='' marshal_as='/base/samples/frame/Frame' name='/RTT/extras/ReadOnlyPointer&lt;/base/samples/frame/Frame&gt;' needs_copy='0' size='0'>
+  <metadata key='orogen:cxx_port_codegen:constructor'><![CDATA[_%s.setDataSample(::RTT::extras::ReadOnlyPointer< ::base::samples::frame::Frame >(new ::base::samples::frame::Frame));]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[orocos-rtt-gnulinux:rtt/extras/ReadOnlyPointer.hpp]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/base/samples/frame/FramePair' name='/RTT/extras/ReadOnlyPointer&lt;/base/samples/frame/FramePair&gt;' needs_copy='0' size='0'>
+  <metadata key='orogen:cxx_port_codegen:constructor'><![CDATA[_%s.setDataSample(::RTT::extras::ReadOnlyPointer< ::base::samples::frame::FramePair >(new ::base::samples::frame::FramePair));]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[orocos-rtt-gnulinux:rtt/extras/ReadOnlyPointer.hpp]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Matrix4d' name='/base/Affine3d' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:35]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/AngleAxisd' name='/base/AngleAxisd' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:34]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Matrix2d' name='/base/Matrix2d' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:26]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Matrix3d' name='/base/Matrix3d' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::Matrix3d]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:27]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Matrix4d' name='/base/Matrix4d' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:28]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Matrix6d' name='/base/Matrix6d' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::Matrix6d]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:29]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/MatrixXd' name='/base/MatrixXd' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:31]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Quaterniond' name='/base/Quaterniond' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::Quaterniond]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:33]]></metadata>
+
+  </opaque>
+  <alias name='/base/Orientation' source='/base/Quaterniond'/>
+  <opaque includes='' marshal_as='/wrappers/Vector2d' name='/base/Vector2d' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::Vector2d]]></metadata>
+<metadata key='doc'><![CDATA[We define these typedefs to workaround alignment requirements for normal
+Eigen types. This reduces the amount of knowledge people have to have to
+manipulate these types -- as well as the structures that use them -- and
+make them usable in Orocos dataflow.
+
+Eigen supports converting them to "standard" eigen types in a
+straightforward way. Moreover, vectorization does not help for small
+sizes]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:19]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Vector3d' name='/base/Vector3d' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::Vector3d]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:20]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Vector4d' name='/base/Vector4d' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:21]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/Vector6d' name='/base/Vector6d' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:22]]></metadata>
+
+  </opaque>
+  <opaque includes='' marshal_as='/wrappers/VectorXd' name='/base/VectorXd' needs_copy='1' size='0'>
+  <metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Eigen.hpp:24]]></metadata>
+
+  </opaque>
+  <compound name='/base/Pose' size='56'>
+    <field name='position' offset='0' type='/base/Vector3d'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:117]]></metadata>
+
+    </field>
+    <field name='orientation' offset='24' type='/base/Quaterniond'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:118]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Pose]]></metadata>
+<metadata key='doc'><![CDATA[@brief Representation for a pose in 3D
+
+Stores the position and orientation part separately
+and is very well suited for storage and interchange,
+since it is a compact representation.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Pose.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:115]]></metadata>
+
+  </compound>
+  <alias name='/base/Position' source='/base/Vector3d'/>
+  <alias name='/base/Position2D' source='/base/Vector2d'/>
+  <compound name='/base/TransformWithCovariance' size='344'>
+    <field name='translation' offset='0' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[The transformation is represented 6D vector [translation orientation]
+Here orientation is the rotational part expressed as a quaternion
+orientation, and t the translational component.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TransformWithCovariance.hpp:31]]></metadata>
+
+    </field>
+    <field name='orientation' offset='24' type='/base/Quaterniond'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TransformWithCovariance.hpp:33]]></metadata>
+
+    </field>
+    <field name='cov' offset='56' type='/base/Matrix6d'>
+    <metadata key='doc'><![CDATA[The uncertainty is represented as a 6x6 matrix, which is the covariance
+matrix of the [translation orientation] representation of the error.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TransformWithCovariance.hpp:38]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::TransformWithCovariance]]></metadata>
+<metadata key='doc'><![CDATA[Class which represents a 3D Transformation with associated uncertainty information.
+
+The uncertainty is represented as a 6x6 matrix, which is the covariance
+matrix of the [r t] representation of the error. Here r is the rotation orientation
+part expressed as a scaled axis of orientation, and t the translational
+component.
+
+The uncertainty information is optional. The hasValidCovariance() method can
+be used to see if uncertainty information is associated with the class.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/TransformWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TransformWithCovariance.hpp:20]]></metadata>
+
+  </compound>
+  <compound name='/base/TwistWithCovariance' size='336'>
+    <field name='vel' offset='0' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Velocity in m/s ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TwistWithCovariance.hpp:17]]></metadata>
+
+    </field>
+    <field name='rot' offset='24' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Rotation rate in rad/s ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TwistWithCovariance.hpp:20]]></metadata>
+
+    </field>
+    <field name='cov' offset='48' type='/base/Matrix6d'>
+    <metadata key='doc'><![CDATA[Uncertainty ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TwistWithCovariance.hpp:23]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::TwistWithCovariance]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/TwistWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/TwistWithCovariance.hpp:9]]></metadata>
+
+  </compound>
+  <compound name='/base/Wrench' size='48'>
+    <field name='force' offset='0' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Force in N ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Wrench.hpp:14]]></metadata>
+
+    </field>
+    <field name='torque' offset='24' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Torque in Nm]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Wrench.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Wrench]]></metadata>
+<metadata key='doc'><![CDATA[Represents the force and torque applied at a point]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Wrench.hpp:11]]></metadata>
+
+  </compound>
+  <enum name='/base/JointState/MODE'>
+    <value symbol='ACCELERATION' value='4'/>
+    <value symbol='EFFORT' value='2'/>
+    <value symbol='POSITION' value='0'/>
+    <value symbol='RAW' value='3'/>
+    <value symbol='SPEED' value='1'/>
+    <value symbol='UNSET' value='5'/>
+  <metadata key='cxxname'><![CDATA[::base::JointState::MODE]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:21]]></metadata>
+
+  </enum>
+  <enum name='/base/Time/Resolution'>
+    <value symbol='Microseconds' value='1000000'/>
+    <value symbol='Milliseconds' value='1000'/>
+    <value symbol='Seconds' value='1'/>
+  <metadata key='cxxname'><![CDATA[::base::Time::Resolution]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Time.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Time.hpp:21]]></metadata>
+
+  </enum>
+  <alias name='/base/TransformWithCovariance/Covariance' source='/base/Matrix6d'/>
+  <alias name='/base/TwistWithCovariance/Covariance' source='/base/Matrix6d'/>
+  <opaque includes='' marshal_as='/wrappers/geometry/Spline' name='/base/geometry/Spline&lt;1&gt;' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::geometry::Spline<1>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/geometry/Spline.hpp:387]]></metadata>
+
+  </opaque>
+  <alias name='/base/geometry/Spline1' source='/base/geometry/Spline&lt;1&gt;'/>
+  <opaque includes='' marshal_as='/wrappers/geometry/Spline' name='/base/geometry/Spline&lt;3&gt;' needs_copy='1' size='0'>
+  <metadata key='cxxname'><![CDATA[::base::geometry::Spline<3>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/geometry/Spline.hpp:387]]></metadata>
+
+  </opaque>
+  <alias name='/base/geometry/Spline3' source='/base/geometry/Spline&lt;3&gt;'/>
+  <alias name='/base/geometry/Spline&lt;2&gt;/vector_t' source='/base/Vector2d'/>
+  <alias name='/base/geometry/Spline&lt;3&gt;/vector_t' source='/base/Vector3d'/>
+  <enum name='/base/geometry/SplineBase/CoordinateType'>
+    <value symbol='DERIVATIVE_TO_NEXT' value='3'/>
+    <value symbol='DERIVATIVE_TO_PRIOR' value='4'/>
+    <value symbol='KNUCKLE_POINT' value='2'/>
+    <value symbol='ORDINARY_POINT' value='1'/>
+    <value symbol='SECOND_DERIVATIVE_TO_NEXT' value='5'/>
+    <value symbol='SECOND_DERIVATIVE_TO_PRIOR' value='6'/>
+    <value symbol='TANGENT_POINT_FOR_NEXT' value='13'/>
+    <value symbol='TANGENT_POINT_FOR_PRIOR' value='14'/>
+  <metadata key='cxxname'><![CDATA[::base::geometry::SplineBase::CoordinateType]]></metadata>
+<metadata key='doc'><![CDATA[types to be used in the interpolate() method]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/geometry/Spline.hpp:109]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/DepthMap/DEPTH_MEASUREMENT_STATE'>
+    <value symbol='MEASUREMENT_ERROR' value='3'/>
+    <value symbol='TOO_FAR' value='1'/>
+    <value symbol='TOO_NEAR' value='2'/>
+    <value symbol='VALID_MEASUREMENT' value='0'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::DepthMap::DEPTH_MEASUREMENT_STATE]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/DepthMap.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:39]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/DepthMap/PROJECTION_TYPE'>
+    <value symbol='PLANAR' value='1'/>
+    <value symbol='POLAR' value='0'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::DepthMap::PROJECTION_TYPE]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/DepthMap.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:47]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/DepthMap/UNIT_AXIS'>
+    <value symbol='UNIT_X' value='0'/>
+    <value symbol='UNIT_Y' value='1'/>
+    <value symbol='UNIT_Z' value='2'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::DepthMap::UNIT_AXIS]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/DepthMap.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:53]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/LASER_RANGE_ERRORS'>
+    <value symbol='END_LASER_RANGE_ERRORS' value='6'/>
+    <value symbol='MAX_RANGE_ERROR' value='5'/>
+    <value symbol='MEASUREMENT_ERROR' value='3'/>
+    <value symbol='OTHER_RANGE_ERRORS' value='4'/>
+    <value symbol='TOO_FAR' value='1'/>
+    <value symbol='TOO_NEAR' value='2'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::LASER_RANGE_ERRORS]]></metadata>
+<metadata key='doc'><![CDATA[Special values for the ranges. If a range has one of these values, then
+it is not valid and the value declares what is going on ]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/LaserScan.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:14]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/frame/frame_mode_t'>
+    <value symbol='COMPRESSED_MODES' value='256'/>
+    <value symbol='MODE_BAYER' value='128'/>
+    <value symbol='MODE_BAYER_BGGR' value='131'/>
+    <value symbol='MODE_BAYER_GBRG' value='132'/>
+    <value symbol='MODE_BAYER_GRBG' value='130'/>
+    <value symbol='MODE_BAYER_RGGB' value='129'/>
+    <value symbol='MODE_BGR' value='4'/>
+    <value symbol='MODE_GRAYSCALE' value='1'/>
+    <value symbol='MODE_JPEG' value='258'/>
+    <value symbol='MODE_PJPG' value='257'/>
+    <value symbol='MODE_PNG' value='259'/>
+    <value symbol='MODE_RGB' value='2'/>
+    <value symbol='MODE_RGB32' value='5'/>
+    <value symbol='MODE_UNDEFINED' value='0'/>
+    <value symbol='MODE_UYVY' value='3'/>
+    <value symbol='RAW_MODES' value='128'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::frame_mode_t]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:36]]></metadata>
+
+  </enum>
+  <enum name='/base/samples/frame/frame_status_t'>
+    <value symbol='STATUS_EMPTY' value='0'/>
+    <value symbol='STATUS_INVALID' value='2'/>
+    <value symbol='STATUS_VALID' value='1'/>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::frame_status_t]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:56]]></metadata>
+
+  </enum>
+  <numeric category='uint' name='/bool' size='1'>
+  <metadata key='orogen_include'><![CDATA[:boost/cstdint.hpp]]></metadata>
+
+  </numeric>
+  <numeric category='float' name='/double' size='8'>
+  <metadata key='orogen_include'/>
+  </numeric>
+  <numeric category='float' name='/float' size='4'>
+  <metadata key='orogen_include'/>
+  </numeric>
+  <numeric category='sint' name='/int32_t' size='4'>
+  <metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+
+  </numeric>
+  <numeric category='sint' name='/int64_t' size='8'>
+  <metadata key='cxxname'><![CDATA[::int64_t]]></metadata>
+<metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/x86_64-linux-gnu/bits/stdint-intn.h:27]]></metadata>
+
+  </numeric>
+  <numeric category='sint' name='/int8_t' size='1'>
+  <metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+
+  </numeric>
+  <numeric category='uint' name='/uint16_t' size='2'>
+  <metadata key='cxxname'><![CDATA[::uint16_t]]></metadata>
+<metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:25]]></metadata>
+
+  </numeric>
+  <numeric category='uint' name='/uint32_t' size='4'>
+  <metadata key='cxxname'><![CDATA[::uint32_t]]></metadata>
+<metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:26]]></metadata>
+
+  </numeric>
+  <numeric category='uint' name='/uint8_t' size='1'>
+  <metadata key='cxxname'><![CDATA[::uint8_t]]></metadata>
+<metadata key='orogen_include'><![CDATA[boost/cstdint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:24]]></metadata>
+
+  </numeric>
+  <compound name='/base/Angle' size='8'>
+    <field name='rad' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[angle in radians.
+this value will always be PI < rad <= PI
+
+@note don't use this value directly. It's only public to allow this class
+to be used as an interface type.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Angle.hpp:29]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Angle]]></metadata>
+<metadata key='doc'><![CDATA[This class represents an angle, and can be used instead of double for
+convenience. The class has a canonical representation of the angle in
+degrees, in the interval PI < rad <= PI.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/commands/Motion2D.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Angle.hpp:19]]></metadata>
+
+  </compound>
+  <compound name='/base/JointState' size='24'>
+    <field name='position' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[Current position of the actuator, in radians for angular
+joints, in m for linear ones
+
+For angular joints that can move more than 360 degrees, this
+accumulates the movement since initialization
+
+If the joint is an angular joint whose motion is constrained to less
+than one full turn, the value should be in [-PI, PI]. base::Angle
+could be used to manipulate it before setting it in this structure
+
+If the joint is an unconstrained angular joint (e.g. a wheel joint),
+the range is [-inf, inf]]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:37]]></metadata>
+
+    </field>
+    <field name='speed' offset='8' type='/float'>
+    <metadata key='doc'><![CDATA[Speed in radians per second for angular actuators, in m/s
+for linear ones
+
+This is an instantaneous speed. It means that, considering two
+consecutive JointState samples,
+   (position1 - position0)/(time1 - * time0).toSeconds()
+is not necessarily equal to 'speed']]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:47]]></metadata>
+
+    </field>
+    <field name='effort' offset='12' type='/float'>
+    <metadata key='doc'><![CDATA[Torque in N.m for angular joints and N for linear ones]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:51]]></metadata>
+
+    </field>
+    <field name='raw' offset='16' type='/float'>
+    <metadata key='doc'><![CDATA[Raw command to/from the actuator, if this is an actuated joint. It
+is commonly a PWM value in [0,1]]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:56]]></metadata>
+
+    </field>
+    <field name='acceleration' offset='20' type='/float'>
+    <metadata key='doc'><![CDATA[Acceleration in radians per square second for angular actuators, in m/ss
+for linear ones ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:60]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::JointState]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the state of a given joint
+
+The joint does not have to necessarily be actuated. This type is also
+used as inputs to controller, in which case the setpoints should be
+tested with the has* and is* predicates (e.g. hasPosition(), ...)
+
+The values given in such structures can only be interpreted when
+associated with kinematics data. In Rock, see the control/robot_model
+package for more information.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointState.hpp:19]]></metadata>
+
+  </compound>
+  <alias name='/base/Orientation2D' source='/double'/>
+  <compound name='/base/Pose2D' size='24'>
+    <field name='position' offset='0' type='/base/Vector2d'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:203]]></metadata>
+
+    </field>
+    <field name='orientation' offset='16' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:204]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Pose2D]]></metadata>
+<metadata key='doc'><![CDATA[Representation for a pose in 2D]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Pose.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:201]]></metadata>
+
+  </compound>
+  <compound name='/base/PoseUpdateThreshold' size='16'>
+    <field name='distance' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:104]]></metadata>
+
+    </field>
+    <field name='angle' offset='8' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:105]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::PoseUpdateThreshold]]></metadata>
+<metadata key='doc'><![CDATA[Represents a pose update threshold, with a number of test methods to see
+if the threshold was met.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Pose.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pose.hpp:72]]></metadata>
+
+  </compound>
+  <compound name='/base/Pressure' size='4'>
+    <field name='pascal' offset='0' type='/float'>
+    <metadata key='doc'><![CDATA[Pressure in pascals
+
+This is made public so that it can be used directly in Rock
+components. You usually should not access it, but instead use one of
+the initializers / accessors]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pressure.hpp:21]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Pressure]]></metadata>
+<metadata key='doc'><![CDATA[Representation of a pressure value
+
+It is internally normalized to a pressure in pascals (the SI unit for
+pressure), but provides accessors and initializers to convert to the most
+common pressure units (bar and PSI)]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Pressure.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pressure.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/Temperature' size='8'>
+    <field name='kelvin' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[temperature in kelvins
+
+
+@note don't use this value directly. It's only public to allow this class
+to be used as an interface type.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Temperature.hpp:25]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Temperature]]></metadata>
+<metadata key='doc'><![CDATA[This class represents a temperature, and can be used instead of double for
+convenience. The class has a canonical representation of the temperature in
+kelvin.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Temperature.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Temperature.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/Time' size='8'>
+    <field name='microseconds' offset='0' type='/int64_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Time.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Time]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Time.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Time.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/Trajectory' size='96'>
+    <field name='speed' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[The speed in which the trajectory should be
+traversed.
+]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Trajectory.hpp:17]]></metadata>
+
+    </field>
+    <field name='spline' offset='8' type='/base/geometry/Spline&lt;3&gt;'>
+    <metadata key='doc'><![CDATA[A spline representing the trajectory that should
+be driven.
+]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Trajectory.hpp:30]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Trajectory]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Trajectory.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Trajectory.hpp:9]]></metadata>
+
+  </compound>
+  <compound name='/base/Waypoint' size='48'>
+    <field name='position' offset='0' type='/base/Vector3d'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Waypoint.hpp:14]]></metadata>
+
+    </field>
+    <field name='heading' offset='24' type='/double'>
+    <metadata key='doc'><![CDATA[heading in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Waypoint.hpp:16]]></metadata>
+
+    </field>
+    <field name='tol_position' offset='32' type='/double'>
+    <metadata key='doc'><![CDATA[tollerance of the position in m]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Waypoint.hpp:19]]></metadata>
+
+    </field>
+    <field name='tol_heading' offset='40' type='/double'>
+    <metadata key='doc'><![CDATA[tollerance of the heading in rad]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Waypoint.hpp:21]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Waypoint]]></metadata>
+<metadata key='doc'><![CDATA[Representation for a pose]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Waypoint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Waypoint.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/JointLimitRange' size='48'>
+    <field name='min' offset='0' type='/base/JointState'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointLimitRange.hpp:11]]></metadata>
+
+    </field>
+    <field name='max' offset='24' type='/base/JointState'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointLimitRange.hpp:12]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::JointLimitRange]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointLimits.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointLimitRange.hpp:9]]></metadata>
+
+  </compound>
+  <compound name='/base/TimeStamped&lt;/base/commands/Motion2D&gt;' size='32'>
+    <field name='translation' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:16]]></metadata>
+
+    </field>
+    <field name='rotation' offset='8' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:17]]></metadata>
+
+    </field>
+    <field name='heading' offset='16' type='/base/Angle'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:18]]></metadata>
+
+    </field>
+    <field name='time' offset='24' type='/base/Time'>
+    <metadata key='doc'><![CDATA[the actual timestamp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/templates/TimeStamped.hpp:59]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/commands/Motion2D]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::TimeStamped<base::commands::Motion2D>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/CommandSamples.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/templates/TimeStamped.hpp:18]]></metadata>
+
+  </compound>
+  <compound name='/base/commands/LinearAngular6DCommand' size='56'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The command timestamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/LinearAngular6DCommand.hpp:16]]></metadata>
+
+    </field>
+    <field name='linear' offset='8' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[The linear part of the command, as (x,y,z) ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/LinearAngular6DCommand.hpp:18]]></metadata>
+
+    </field>
+    <field name='angular' offset='32' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[The angular part of the command, as (r,p,y) ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/LinearAngular6DCommand.hpp:20]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::commands::LinearAngular6DCommand]]></metadata>
+<metadata key='doc'><![CDATA[Common command structure for all controller types, in all control frames ]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/commands/LinearAngular6DCommand.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/LinearAngular6DCommand.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/commands/Motion2D' size='24'>
+    <field name='translation' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:16]]></metadata>
+
+    </field>
+    <field name='rotation' offset='8' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:17]]></metadata>
+
+    </field>
+    <field name='heading' offset='16' type='/base/Angle'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:18]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::commands::Motion2D]]></metadata>
+<metadata key='doc'><![CDATA[A unified motion control data structure for differential drive-based
+ robots.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/commands/Motion2D.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/commands/Speed6D' size='48'>
+    <field name='surge' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:13]]></metadata>
+
+    </field>
+    <field name='sway' offset='8' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:14]]></metadata>
+
+    </field>
+    <field name='heave' offset='16' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:15]]></metadata>
+
+    </field>
+    <field name='roll' offset='24' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:17]]></metadata>
+
+    </field>
+    <field name='pitch' offset='32' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:18]]></metadata>
+
+    </field>
+    <field name='yaw' offset='40' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:19]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::commands::Speed6D]]></metadata>
+<metadata key='doc'><![CDATA[A unified speed control data structure for 6-dof vehicles (e.g. AUVs)]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/commands/Speed6D.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Speed6D.hpp:11]]></metadata>
+
+  </compound>
+  <alias name='/base/LinearAngular6DCommand' source='/base/commands/LinearAngular6DCommand'/>
+  <compound name='/base/samples/BodyState' size='688'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Time-stamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/BodyState.hpp:40]]></metadata>
+
+    </field>
+    <field name='pose' offset='8' type='/base/TransformWithCovariance'>
+    <metadata key='doc'><![CDATA[Robot pose: rotation in radians and translation in meters ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/BodyState.hpp:43]]></metadata>
+
+    </field>
+    <field name='velocity' offset='352' type='/base/TwistWithCovariance'>
+    <metadata key='doc'><![CDATA[TwistWithCovariance: Linear[m/s] and Angular[rad/s] Velocity of the Body */
+It is assumed here that velocity is the derivative of a delta pose for
+a given interval. When such interval tends to zero, one could talk
+of instantaneous velocity ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/BodyState.hpp:49]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::BodyState]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the state of a rigid body
+
+This is among other things used to express frame transformations by
+Rock's transformer
+
+Given a source and target frame, this structure expresses the _frame
+change_ between these two frames. In effect, it represents the state of
+the source frame expressed in the target frame.
+
+Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards), you
+should use a X-forward, right handed coordinate system when assigning
+frames to bodies (i.e.  X=forward, Y=left, Z=up). In addition,
+world-fixed frames should be aligned to North (North-East-Up)
+
+For instance, if sourceFrame is "body" and targetFrame is "world", then
+the BodyState object is the state of body in the world frame
+(usually, the world frame has an arbitrary origin and a North-East-Up
+orientation).]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/BodyState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/BodyState.hpp:31]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/IMUSensors' size='80'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Timestamp of the orientation reading ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/IMUSensors.hpp:11]]></metadata>
+
+    </field>
+    <field name='acc' offset='8' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[raw accelerometer readings ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/IMUSensors.hpp:14]]></metadata>
+
+    </field>
+    <field name='gyro' offset='32' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[raw gyro reading]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/IMUSensors.hpp:17]]></metadata>
+
+    </field>
+    <field name='mag' offset='56' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[raw magnetometer reading]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/IMUSensors.hpp:20]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::IMUSensors]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/IMUSensors.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/IMUSensors.hpp:8]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Motion2D' size='32'>
+    <field name='translation' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:16]]></metadata>
+
+    </field>
+    <field name='rotation' offset='8' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:17]]></metadata>
+
+    </field>
+    <field name='heading' offset='16' type='/base/Angle'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/commands/Motion2D.hpp:18]]></metadata>
+
+    </field>
+    <field name='time' offset='24' type='/base/Time'>
+    <metadata key='doc'><![CDATA[the actual timestamp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/templates/TimeStamped.hpp:59]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/TimeStamped</base/commands/Motion2D>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Motion2D]]></metadata>
+<metadata key='doc'><![CDATA[Time stamped version of a Motion2D command]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/CommandSamples.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/CommandSamples.hpp:27]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Pressure' size='16'>
+    <field name='pascal' offset='0' type='/float'>
+    <metadata key='doc'><![CDATA[Pressure in pascals
+
+This is made public so that it can be used directly in Rock
+components. You usually should not access it, but instead use one of
+the initializers / accessors]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Pressure.hpp:21]]></metadata>
+
+    </field>
+    <field name='time' offset='8' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The sample timestamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pressure.hpp:16]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/Pressure]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Pressure]]></metadata>
+<metadata key='doc'><![CDATA[Timestamped pressure ]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Pressure.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pressure.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/RigidBodyAcceleration' size='200'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:27]]></metadata>
+
+    </field>
+    <field name='acceleration' offset='8' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Linear acceleration in m/s2 ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:30]]></metadata>
+
+    </field>
+    <field name='cov_acceleration' offset='32' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the linear acceleration]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:33]]></metadata>
+
+    </field>
+    <field name='angular_acceleration' offset='104' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Angular acceleration in rad/s2 ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:36]]></metadata>
+
+    </field>
+    <field name='cov_angular_acceleration' offset='128' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the angular acceleration]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:39]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::RigidBodyAcceleration]]></metadata>
+<metadata key='doc'><![CDATA[Representation of accelerations of a body in a given (unspecified) fixed
+frame of reference
+
+While the frame of reference is unspecified, it will usually be the
+inertial frame. We encourage Rock code to use the body-fixed frame
+as the frame of expression.
+
+Indeed, Sensors (e.g. gyros, accelerometers) and models (e.g.
+hydrodynamic models) give access to velocities and accelerations w.r.t.
+the inertial frame, but expressed in the body frame. However, expressing
+the velocities/accelerations in the world frame from these
+sensing/estimation methods would require to have an estimate
+of the system's pose in the world, which is a harder thing to get.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/RigidBodyAcceleration.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyAcceleration.hpp:23]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Temperature' size='16'>
+    <field name='kelvin' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[temperature in kelvins
+
+
+@note don't use this value directly. It's only public to allow this class
+to be used as an interface type.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Temperature.hpp:25]]></metadata>
+
+    </field>
+    <field name='time' offset='8' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The sample timestamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Temperature.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/Temperature]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Temperature]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Temperature.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Temperature.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Wrench' size='56'>
+    <field name='force' offset='0' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Force in N ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Wrench.hpp:14]]></metadata>
+
+    </field>
+    <field name='torque' offset='24' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Torque in Nm]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/Wrench.hpp:17]]></metadata>
+
+    </field>
+    <field name='time' offset='48' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Wrench.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/Wrench]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Wrench]]></metadata>
+<metadata key='doc'><![CDATA[Wrench sample with Force, Torque and sampled Time]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Wrench.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/base/samples/DepthMap/scalar' source='/float'/>
+  <alias name='/base/samples/DepthMap/uint32_t' source='/uint32_t'/>
+  <alias name='/base/samples/DistanceImage/scalar' source='/float'/>
+  <alias name='/base/samples/LaserScan/uint32_t' source='/uint32_t'/>
+  <alias name='/base/samples/SonarBeam/uint8_t' source='/uint8_t'/>
+  <compound name='/base/samples/frame/frame_size_t' size='4'>
+    <field name='width' offset='0' type='/uint16_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:32]]></metadata>
+
+    </field>
+    <field name='height' offset='2' type='/uint16_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:33]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::frame_size_t]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:23]]></metadata>
+
+  </compound>
+  <container kind='/std/string' name='/std/string' of='/int8_t' size='32'>
+  <metadata key='cxxname'><![CDATA[::std::string]]></metadata>
+<metadata key='doc'><![CDATA[A string of @c char]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:boost/cstdint.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[:string]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stringfwd.h:79]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Angle&gt;' of='/base/Angle' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Angle, std::allocator<base::Angle> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/commands/Motion2D.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/JointLimitRange&gt;' of='/base/JointLimitRange' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::JointLimitRange, std::allocator<base::JointLimitRange> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointLimits.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/JointState&gt;' of='/base/JointState' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::JointState, std::allocator<base::JointState> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Time&gt;' of='/base/Time' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Time, std::allocator<base::Time> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Time.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Trajectory&gt;' of='/base/Trajectory' size='24'>
+  <metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Trajectory.hpp]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Vector3d&gt;' of='/base/Vector3d' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<Eigen::Matrix<double, 3, 1, 2, 3, 1>, std::allocator<Eigen::Matrix<double, 3, 1, 2, 3, 1> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Vector4d&gt;' of='/base/Vector4d' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<Eigen::Matrix<double, 4, 1, 2, 4, 1>, std::allocator<Eigen::Matrix<double, 4, 1, 2, 4, 1> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Waypoint&gt;' of='/base/Waypoint' size='24'>
+  <metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Waypoint.hpp]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Wrench&gt;' of='/base/Wrench' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Wrench, std::allocator<base::Wrench> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/double&gt;' of='/double' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<double, std::allocator<double> >]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/float&gt;' of='/float' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<float, std::allocator<float> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/uint32_t&gt;' of='/uint32_t' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<unsigned int, std::allocator<unsigned int> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:boost/cstdint.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/uint8_t&gt;' of='/uint8_t' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<unsigned char, std::allocator<unsigned char> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:boost/cstdint.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/std/string&gt;' of='/std/string' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<std::basic_string<char>, std::allocator<std::basic_string<char> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:boost/cstdint.hpp]]></metadata>
+<metadata key='orogen_include'><![CDATA[:string]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/std/vector&lt;/base/JointState&gt;&gt;' of='/std/vector&lt;/base/JointState&gt;' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<std::vector<base::JointState, std::allocator<base::JointState> >, std::allocator<std::vector<base::JointState, std::allocator<base::JointState> > > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <compound name='/base/JointLimits' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointLimitRange&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/JointLimitRange>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::JointLimits]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointLimits.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointLimits.hpp:9]]></metadata>
+
+  </compound>
+  <alias name='/base/JointTrajectory' source='/std/vector&lt;/base/JointState&gt;'/>
+  <compound name='/base/JointTransform' size='88'>
+    <field name='sourceFrame' offset='0' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointTransform.hpp:19]]></metadata>
+
+    </field>
+    <field name='targetFrame' offset='32' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointTransform.hpp:20]]></metadata>
+
+    </field>
+    <field name='rotationAxis' offset='64' type='/base/Vector3d'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointTransform.hpp:21]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::JointTransform]]></metadata>
+<metadata key='doc'><![CDATA[defines the frame transformation for a joint,
+and the rotation axis]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointTransform.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointTransform.hpp:17]]></metadata>
+
+  </compound>
+  <compound name='/base/JointsTrajectory' size='72'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/std/vector&lt;/base/JointState&gt;&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+    <field name='times' offset='48' type='/std/vector&lt;/base/Time&gt;'>
+    <metadata key='doc'><![CDATA[@brief optional array of time values corresponding to the samples of the JointState
+
+This vector needs to be either empty or the same size as each of the
+std::vector<JointState> in the elements vector.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointsTrajectory.hpp:54]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</std/vector</base/JointState>>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::JointsTrajectory]]></metadata>
+<metadata key='doc'><![CDATA[@brief Holds a time-series of JointStates for multiple joints
+
+This structure holds a time-series in the form of std::vector of JointState,
+for multiple optionally named joints.
+
+The time series can have optional time information attached to each sample
+in the series through the times member.
+
+For the data-type to be valid, the length of each time series needs to be
+the same for all joints. The times vector needs to be either empty or also
+of that size
+
+How to access the state of a joint at a given sample:
+     elements[joint_index][sample_number]
+The first index corresponds to the indices in the name vector. Second index to the time step.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointsTrajectory.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointsTrajectory.hpp:32]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector&lt;/base/JointLimitRange&gt;' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointLimitRange&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::JointLimitRange>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector&lt;/base/JointState&gt;' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointState&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::JointState>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector&lt;/base/Wrench&gt;' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/Wrench&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::Wrench>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector&lt;/std/vector&lt;/base/JointState&gt;&gt;' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/std/vector&lt;/base/JointState&gt;&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<std::vector<base::JointState, std::allocator<base::JointState> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/DepthMap' size='144'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Reference timestamp for the depth map sample.
+This timestamp is used for temporal alignment to other data samples
+and transformations.
+It is important to always set here a meaningful value.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:65]]></metadata>
+
+    </field>
+    <field name='timestamps' offset='8' type='/std/vector&lt;/base/Time&gt;'>
+    <metadata key='doc'><![CDATA[The timestamps can be either one timestamp for all measurements,
+two for interpolation, per vertical entries, per horizontal entries
+or one per measurement.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:71]]></metadata>
+
+    </field>
+    <field name='vertical_projection' offset='32' type='/base/samples/DepthMap/PROJECTION_TYPE'>
+    <metadata key='doc'><![CDATA[Defines the vertical projection type of the depth map.
+If polar, the vertical intervals are angular rotations around the Y-unit axis.
+If planar, the vertical intervals are positions on an image plane coordinate frame.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:77]]></metadata>
+
+    </field>
+    <field name='horizontal_projection' offset='36' type='/base/samples/DepthMap/PROJECTION_TYPE'>
+    <metadata key='doc'><![CDATA[Defines the horizontal projection type of the depth map.
+If polar, the horizontal intervals are angular rotations around the Z-unit axis.
+If planar, the horizontal intervals are positions on an image plane coordinate frame.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:83]]></metadata>
+
+    </field>
+    <field name='vertical_interval' offset='40' type='/std/vector&lt;/double&gt;'>
+    <metadata key='doc'><![CDATA[The interval can describe a position on a planar plane or an
+angle. The interval is interpreted as defined by the vertical projection type.
+In planar projection mode the vertical intervals are y coordinates on an
+depth-image plane, with zero in the middle of the plane.
+In polar projection mode the vertical intervals are angular rotations
+around the Y-unit axis. Vertical angles must always be ordered from a smaller
+to a higher value, since the rows of the data matrices are interpreted from the upper
+to the lower row.
+The field has either two or |vertical_size| entries. In the case of two
+entries the intervals are interpreted as upper and under boundaries. The
+transformation for each measurement will be interpolated.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:97]]></metadata>
+
+    </field>
+    <field name='horizontal_interval' offset='64' type='/std/vector&lt;/double&gt;'>
+    <metadata key='doc'><![CDATA[The interval can describe a position on a planar plane or an
+angle. The interval is interpreted as defined by the horizontal projection type.
+In planar projection mode the horizontal intervals are x coordinates on an
+depth-image plane, with zero in the middle of the plane.
+In polar projection mode the horizontal intervals are angular rotations
+around the Z-unit axis. Horizontal angles must always be ordered from a higher
+to a smaller value, since the columns of the data matrices are interpreted
+from the left to the right.
+The field has either two or |horizontal_size| entries. In the case of two
+entries the intervals are interpreted as left and right boundaries. The
+transformation for each measurement will be interpolated.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:111]]></metadata>
+
+    </field>
+    <field name='vertical_size' offset='88' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[Number of vertical depth samples ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:114]]></metadata>
+
+    </field>
+    <field name='horizontal_size' offset='92' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[Number of horizontal depth samples ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:117]]></metadata>
+
+    </field>
+    <field name='distances' offset='96' type='/std/vector&lt;/float&gt;'>
+    <metadata key='doc'><![CDATA[The distance samples. The data is arranged in a row major order to simplify
+the usage as a distance image. One row is a set of horizontal arranged single measurements.
+The data for a measurement (vertical_index, horizontal_index) is in
+distances[(vertical_index * horizontal_size) + horizontal_index].]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:124]]></metadata>
+
+    </field>
+    <field name='remissions' offset='120' type='/std/vector&lt;/float&gt;'>
+    <metadata key='doc'><![CDATA[The remission samples. This field is optional.
+The data is arranged in a row major order to simplify the usage as a remission image.
+The data for a value (vertical_index, horizontal_index) is in
+remissions[(vertical_index * horizontal_size) + horizontal_index].]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:131]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::DepthMap]]></metadata>
+<metadata key='doc'><![CDATA[The DepthMap type provides distance and optional remission values in 3D.
+The information is stored in a vector in a row major form, to simplify the usage as a distance image.
+One row is a set of horizontal arranged single measurements with an identical vertical position or angle.
+The distance and remission fields can therefore be seen as a image plane or a matrix.
+The horizontal and vertical intervals can be in polar or in planar form. In polar they are interpreted
+as angles and in planar form they are interpreted as coordinates on a depth-image plane.
+Horizontal intervals are always defined from left to right and vertical intervals are always
+defined top down.
+Each field of intervals can either have two entries, which define a range of regular arranged measurements,
+or one entry per measurement to represent the irregular case.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/DepthMap.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DepthMap.hpp:29]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/DistanceImage' size='56'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[original timestamp of the camera image]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:35]]></metadata>
+
+    </field>
+    <field name='width' offset='8' type='/uint16_t'>
+    <metadata key='doc'><![CDATA[width (x) value in pixels]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:38]]></metadata>
+
+    </field>
+    <field name='height' offset='10' type='/uint16_t'>
+    <metadata key='doc'><![CDATA[height (y) value in pixels]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:40]]></metadata>
+
+    </field>
+    <field name='scale_x' offset='12' type='/float'>
+    <metadata key='doc'><![CDATA[scale value to apply to the x axis]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:44]]></metadata>
+
+    </field>
+    <field name='scale_y' offset='16' type='/float'>
+    <metadata key='doc'><![CDATA[scale value to apply to the y axis]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:46]]></metadata>
+
+    </field>
+    <field name='center_x' offset='20' type='/float'>
+    <metadata key='doc'><![CDATA[center offset to apply to the x axis]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:49]]></metadata>
+
+    </field>
+    <field name='center_y' offset='24' type='/float'>
+    <metadata key='doc'><![CDATA[center offset to apply to the y axis]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:51]]></metadata>
+
+    </field>
+    <field name='data' offset='32' type='/std/vector&lt;/float&gt;'>
+    <metadata key='doc'><![CDATA[distance values stored in row major order. NaN is used as the no value type.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:54]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::DistanceImage]]></metadata>
+<metadata key='doc'><![CDATA[2D array structure representing a distance image for a pinhole camera model.
+
+The grid pixels are scaled such that (x*scale_x)+center_x = p_x are the
+projective plane coordinates given a grid index x. This of course applies
+to y as well.
+
+The data array is a row major flattened version of the image matrix,
+giving the distance value d of the image points.  The relation is such
+that for a point on the projection plane, the 3D point z can be calculated
+as (p_x,p_y,1)*d = z.
+
+NOTE: unfortunately the scale and center is directly inverse to the convention
+used in:
+http://docs.opencv.org/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
+for the time being, scale_x and scale_y are kept public for legacy code.
+It is recommended to use the functions operating on it instead.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/DistanceImage.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/DistanceImage.hpp:32]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Joints' size='56'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointState&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+    <field name='time' offset='48' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The sample timestamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Joints.hpp:20]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/JointState>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Joints]]></metadata>
+<metadata key='doc'><![CDATA[Data structure that gives out state readings for a set of joints]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Joints.hpp:17]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/LaserScan' size='88'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The timestamp of this reading. The timestamp is the time at which the
+laser passed the zero step (i.e. the step at the back of the device,
+which is distinct from the measurement 0)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:30]]></metadata>
+
+    </field>
+    <field name='start_angle' offset='8' type='/double'>
+    <metadata key='doc'><![CDATA[The angle at which the range readings start. Zero is at the front of
+the device and turns counter-clockwise.
+This value is in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:36]]></metadata>
+
+    </field>
+    <field name='angular_resolution' offset='16' type='/double'>
+    <metadata key='doc'><![CDATA[Angle difference between two scan point in radians;]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:40]]></metadata>
+
+    </field>
+    <field name='speed' offset='24' type='/double'>
+    <metadata key='doc'><![CDATA[The rotation speed of the laserbeam in radians/seconds]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:44]]></metadata>
+
+    </field>
+    <field name='ranges' offset='32' type='/std/vector&lt;/uint32_t&gt;'>
+    <metadata key='doc'><![CDATA[The ranges themselves: the distance to obstacles in millimeters]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:48]]></metadata>
+
+    </field>
+    <field name='minRange' offset='56' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[minimal valid range returned by laserscanner ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:51]]></metadata>
+
+    </field>
+    <field name='maxRange' offset='60' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[maximal valid range returned by laserscanner ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:54]]></metadata>
+
+    </field>
+    <field name='remission' offset='64' type='/std/vector&lt;/float&gt;'>
+    <metadata key='doc'><![CDATA[The remission value from the laserscan.
+This value is not normalised and depends on various factors, like distance,
+angle of incidence and reflectivity of object.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:60]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::LaserScan]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/LaserScan.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/LaserScan.hpp:23]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Pointcloud' size='56'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pointcloud.hpp:15]]></metadata>
+
+    </field>
+    <field name='points' offset='8' type='/std/vector&lt;/base/Vector3d&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pointcloud.hpp:17]]></metadata>
+
+    </field>
+    <field name='colors' offset='32' type='/std/vector&lt;/base/Vector4d&gt;'>
+    <metadata key='doc'><![CDATA[Colors of each point if available,
+leave empty if points are uncolored.
+Otherwise, it should have the same size
+as the points vector.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pointcloud.hpp:25]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::Pointcloud]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Pointcloud.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Pointcloud.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/PoseWithCovariance' size='416'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Reference timestamp of the pose sample ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/PoseWithCovariance.hpp:27]]></metadata>
+
+    </field>
+    <field name='frame_id' offset='8' type='/std/string'>
+    <metadata key='doc'><![CDATA[ID of the reference frame where this pose is expressed in ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/PoseWithCovariance.hpp:30]]></metadata>
+
+    </field>
+    <field name='object_frame_id' offset='40' type='/std/string'>
+    <metadata key='doc'><![CDATA[ID of the object frame defined by this pose ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/PoseWithCovariance.hpp:33]]></metadata>
+
+    </field>
+    <field name='transform' offset='72' type='/base/TransformWithCovariance'>
+    <metadata key='doc'><![CDATA[Pose of the object frame in the reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/PoseWithCovariance.hpp:36]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::PoseWithCovariance]]></metadata>
+<metadata key='doc'><![CDATA[Represents a 3D pose with uncertainty of the frame 'object_frame_id' in the frame 'frame_id'.
+A frame ID shall be globally unique and correspond to a coordinate system.
+Following the [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards)
+coordinate systems are right handed with X forward, Y left and Z up.
+
+The pose \f$ ^{reference}_{object}T \f$ in this structure transforms a vector \f$ v_{object} \f$
+from the object frame to the reference frame:
+\f$ v_{reference} = ^{reference}_{object}T \cdot v_{object} \f$
+Example of a transformation chain:
+\f$ ^{world}_{sensor}T = ^{world}_{body}T \cdot ^{body}_{sensor}T \f$]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/PoseWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/PoseWithCovariance.hpp:23]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/RigidBodyState' size='464'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:36]]></metadata>
+
+    </field>
+    <field name='sourceFrame' offset='8' type='/std/string'>
+    <metadata key='doc'><![CDATA[Name of the source reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:39]]></metadata>
+
+    </field>
+    <field name='targetFrame' offset='40' type='/std/string'>
+    <metadata key='doc'><![CDATA[Name of the target reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:42]]></metadata>
+
+    </field>
+    <field name='position' offset='72' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Position in m of sourceFrame's origin expressed in targetFrame]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:46]]></metadata>
+
+    </field>
+    <field name='cov_position' offset='96' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the position]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:49]]></metadata>
+
+    </field>
+    <field name='orientation' offset='168' type='/base/Quaterniond'>
+    <metadata key='doc'><![CDATA[Orientation of targetFrame expressed in sourceFrame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:52]]></metadata>
+
+    </field>
+    <field name='cov_orientation' offset='200' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the orientation as an axis/angle manifold in
+body coordinates]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:56]]></metadata>
+
+    </field>
+    <field name='velocity' offset='272' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Velocity in m/s of sourceFrame relative to targetFrame,
+expressed in targetFrame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:60]]></metadata>
+
+    </field>
+    <field name='cov_velocity' offset='296' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance of the velocity]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:63]]></metadata>
+
+    </field>
+    <field name='angular_velocity' offset='368' type='/base/Vector3d'>
+    <metadata key='doc'><![CDATA[Angular Velocity of sourceFrame relative to targetFrame,
+expressed in sourceFrame, as an axis-angle representation
+
+The direction of the vector is the axis, its length the speed ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:69]]></metadata>
+
+    </field>
+    <field name='cov_angular_velocity' offset='392' type='/base/Matrix3d'>
+    <metadata key='doc'><![CDATA[Covariance of the angular velocity]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:72]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::RigidBodyState]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the state of a rigid body
+
+This is among other things used to express frame transformations by
+Rock's transformer
+
+Given a source and target frame, this structure expresses the _frame
+change_ between these two frames. In effect, it represents the state of
+the source frame expressed in the target frame.
+
+Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards), you
+should use a X-forward, right handed coordinate system when assigning
+frames to bodies (i.e.  X=forward, Y=left, Z=up). In addition,
+world-fixed frames should be aligned to North (North-West-Up, aka NWU)
+
+For instance, if sourceFrame is "body" and targetFrame is "world", then
+the RigidBodyState object is the state of body in the world frame
+(usually, the world frame has an arbitrary origin and a North-West-Up
+orientation).]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/RigidBodyState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/RigidBodyState.hpp:31]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Sonar' size='120'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[A reference timestamp for the structure
+
+This is a bit of a bummer. When aggregating scanning sonar data, this
+field has not much sense. However, aggregating scanning sonar is
+meaningful only if the sonar does not move, so it is often possible to
+find a timestamp that does make sense, but YMMV
+
+Advice: always set to a meaningful value as a lot of processing-related
+algorithms expect one value. If you can't have *one*, then split your
+scanning sonar into separate Sonar structure (one per beam).]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:67]]></metadata>
+
+    </field>
+    <field name='timestamps' offset='8' type='/std/vector&lt;/base/Time&gt;'>
+    <metadata key='doc'><![CDATA[The time at which the beam(s) acquisition started
+
+This is useful only if each beam have different acquisition times. If
+not, the beam time is taken from the time field.
+
+@see getBeamAcquisitionStartTime]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:76]]></metadata>
+
+    </field>
+    <field name='bin_duration' offset='32' type='/base/Time'>
+    <metadata key='doc'><![CDATA["Size" of one bin
+
+Sonars basically "slice" the echo return in the time domain, in what we
+call "bins". Each bin has a starting point that is equal to
+
+    bin_duration * bin_index + beam_acquisition_time
+
+and is itself bin_duration wide. Conversion to the space domain requires
+to know the speed of sound.
+
+@see getBeamAcquisitionStartTime getBinStartTime getBinStartDistance]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:90]]></metadata>
+
+    </field>
+    <field name='beam_width' offset='40' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[Opening of the beam orthogonal to the device's Z direction
+
+This is usually along the scanning axis (for a scanning sonar), or in the
+common plane of all the beams (for a multibeam sonar)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:97]]></metadata>
+
+    </field>
+    <field name='beam_height' offset='48' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[Opening of the beam along the device's Z direction
+
+This is usually orthogonal to the scanning axis (for a scanning sonar),
+or orthogonal to the common plane of all the beams (for a multibeam sonar)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:104]]></metadata>
+
+    </field>
+    <field name='bearings' offset='56' type='/std/vector&lt;/base/Angle&gt;'>
+    <metadata key='doc'><![CDATA[Each beam's bearing
+
+This is the position of the beam center with respect to the "front" of
+the sonar (which is at 0)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:111]]></metadata>
+
+    </field>
+    <field name='speed_of_sound' offset='80' type='/float'>
+    <metadata key='doc'><![CDATA[The speed of sound in water at the time of acquisition and in m/s]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:114]]></metadata>
+
+    </field>
+    <field name='bin_count' offset='84' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[Number of bins in a beam ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:117]]></metadata>
+
+    </field>
+    <field name='beam_count' offset='88' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[Number of beams in the structure ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:120]]></metadata>
+
+    </field>
+    <field name='bins' offset='96' type='/std/vector&lt;/float&gt;'>
+    <metadata key='doc'><![CDATA[The bin values
+
+Bin values must be normalized, i.e. gain effects must be corrected and -
+as much as made possible by the sonar's specification - converted to a
+linear scale where 1.0 means that the signal received by the transducer
+is equal to the signal transmittd.
+
+The data is stored beam-first, that is the data for beam N starts at N *
+bin_count and ends at (N + 1) * bin_count]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:132]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::Sonar]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the data acquired by a sonar
+
+The data structure can be used to represent data from both mechanical
+scanning and multibeam sonars. Let's see now the most common use-cases for
+the structure
+
+In the mechanical-scanning sonar case, one would usually create one structure
+per beam. The fromBeam helper can be used to create and initialize the
+structure easily:
+
+@code
+Sonar single_beam = Sonar::fromBeam(timestamp, bins, bearing);
+@endcode
+
+In the multibeam case, one would initialize the structure and then fill it
+with beams
+
+@code
+Sonar multibeam(timestamp, bin_count);
+for (int i = 0; i < bin_count; ++i)
+   multibeam.pushBeam(bin_data_for_beam_i);
+multibeam.setRegularBeamBearings(start_bearing, interval_bearing);
+@encode
+
+A scanning sonar that would happen to be static can also have its beams
+"aggregated" in a single structure, for instance if some multibeam-specific
+algorithm can be used to process it. In this case, one timestamp should be
+provided by beam, and a 'global' timestamp usually will need to be picked
+in order for e.g. the stream aligner to work.
+
+@code
+Sonar static_scanning_sonar(timestamp, bin_count);
+for (int i = 0; i < bin_count; ++i)
+   multibeam.pushBeam(time_for_beam_i, bin_data_for_beam_i);
+multibeam.setRegularBeamBearings(start_bearing, interval_bearing);
+@encode]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Sonar.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Sonar.hpp:53]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/SonarBeam' size='64'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[timestamp of the sonar beam]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:14]]></metadata>
+
+    </field>
+    <field name='bearing' offset='8' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[direction of the sonar beam in radians [-pi,+pi]
+zero is at the front]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:18]]></metadata>
+
+    </field>
+    <field name='sampling_interval' offset='16' type='/double'>
+    <metadata key='doc'><![CDATA[sampling interval of each range bin in secs]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:21]]></metadata>
+
+    </field>
+    <field name='speed_of_sound' offset='24' type='/float'>
+    <metadata key='doc'><![CDATA[speed of sound
+this takes the medium into account]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:25]]></metadata>
+
+    </field>
+    <field name='beamwidth_horizontal' offset='28' type='/float'>
+    <metadata key='doc'><![CDATA[horizontal beamwidth of the sonar beam in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:28]]></metadata>
+
+    </field>
+    <field name='beamwidth_vertical' offset='32' type='/float'>
+    <metadata key='doc'><![CDATA[vertical beamwidth of the sonar beam in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:31]]></metadata>
+
+    </field>
+    <field name='beam' offset='40' type='/std/vector&lt;/uint8_t&gt;'>
+    <metadata key='doc'><![CDATA[received echoes (bins) along the beam]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::SonarBeam]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/SonarBeam.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarBeam.hpp:10]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/SonarScan' size='120'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The time at which this sonar scan has been captured]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:100]]></metadata>
+
+    </field>
+    <field name='data' offset='8' type='/std/vector&lt;/uint8_t&gt;'>
+    <metadata key='doc'><![CDATA[The raw data of the sonar scan]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:103]]></metadata>
+
+    </field>
+    <field name='time_beams' offset='32' type='/std/vector&lt;/base/Time&gt;'>
+    <metadata key='doc'><![CDATA[Time stamp for each sonar beam
+if the time stamp is 1 January 1970
+the beam is regarded as not be set
+vector can be empty in this case time
+is used for all beams]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:110]]></metadata>
+
+    </field>
+    <field name='number_of_beams' offset='56' type='/uint16_t'>
+    <metadata key='doc'><![CDATA[number of beams
+this can be interpreted as image width]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:114]]></metadata>
+
+    </field>
+    <field name='number_of_bins' offset='58' type='/uint16_t'>
+    <metadata key='doc'><![CDATA[number of bins
+this can be interpreted as image height]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:118]]></metadata>
+
+    </field>
+    <field name='start_bearing' offset='64' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[The angle at which the reading starts. Zero is at the front of
+the device and turns counter-clockwise.
+This value is in radians
+
+All beams are stored from left to right to match the memory
+layout of an image !!! Therefore the end bearing is usually
+smaller than the start bearing]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:128]]></metadata>
+
+    </field>
+    <field name='angular_resolution' offset='72' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[Angle difference between two beams in radians
+The beams are stored from left to right
+to match the memory layout of an image
+
+This value must be always positive !]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:135]]></metadata>
+
+    </field>
+    <field name='sampling_interval' offset='80' type='/double'>
+    <metadata key='doc'><![CDATA[sampling interval of each range bin in secs]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:138]]></metadata>
+
+    </field>
+    <field name='speed_of_sound' offset='88' type='/float'>
+    <metadata key='doc'><![CDATA[speed of sound
+this takes the medium into account]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:142]]></metadata>
+
+    </field>
+    <field name='beamwidth_horizontal' offset='96' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[horizontal beam width of the sonar beam in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:145]]></metadata>
+
+    </field>
+    <field name='beamwidth_vertical' offset='104' type='/base/Angle'>
+    <metadata key='doc'><![CDATA[vertical beam width of the sonar beam in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:148]]></metadata>
+
+    </field>
+    <field name='memory_layout_column' offset='112' type='/bool'>
+    <metadata key='doc'><![CDATA[if set to true one sonar beam is stored per column
+otherwise per row]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:152]]></metadata>
+
+    </field>
+    <field name='polar_coordinates' offset='113' type='/bool'>
+    <metadata key='doc'><![CDATA[if set to true the bins are interpreted in polar coordinates
+otherwise in Cartesian coordinates
+
+Some imaging sonars store their data in Cartesian rather than
+polar coordinates (BlueView)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:159]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::SonarScan]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/SonarScan.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/SonarScan.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Wrenches' size='56'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/Wrench&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+    <field name='time' offset='48' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Wrenches.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/Wrench>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Wrenches]]></metadata>
+<metadata key='doc'><![CDATA[A named vector of base::WrenchState with sampled Time.]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Wrenches.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Wrenches.hpp:13]]></metadata>
+
+  </compound>
+  <alias name='/base/commands/Joints' source='/base/samples/Joints'/>
+  <compound name='/base/samples/frame/frame_attrib_t' size='64'>
+    <field name='data_' offset='0' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:18]]></metadata>
+
+    </field>
+    <field name='name_' offset='32' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:19]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::frame_attrib_t]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:16]]></metadata>
+
+  </compound>
+  <container kind='/std/vector' name='/std/vector&lt;/base/JointTransform&gt;' of='/base/JointTransform' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::JointTransform, std::allocator<base::JointTransform> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointTransform.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/samples/frame/frame_attrib_t&gt;' of='/base/samples/frame/frame_attrib_t' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::samples::frame::frame_attrib_t, std::allocator<base::samples::frame::frame_attrib_t> >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <compound name='/base/JointTransformVector' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointTransform&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/JointTransform>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::JointTransformVector]]></metadata>
+<metadata key='doc'><![CDATA[Vector of JointTranformations with added functionality
+to fill a vector of RigidBodyStates given a jointsState sample]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/JointTransform.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/JointTransform.hpp:28]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector&lt;/base/JointTransform&gt;' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:31]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointTransform&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:34]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::JointTransform>]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Joints.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/NamedVector.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/frame/Frame' size='88'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The time at which this frame has been captured
+
+This is obviously an estimate]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:235]]></metadata>
+
+    </field>
+    <field name='received_time' offset='8' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The time at which this frame has been received on the system ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:237]]></metadata>
+
+    </field>
+    <field name='image' offset='16' type='/std/vector&lt;/uint8_t&gt;'>
+    <metadata key='doc'><![CDATA[The raw data ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:240]]></metadata>
+
+    </field>
+    <field name='attributes' offset='40' type='/std/vector&lt;/base/samples/frame/frame_attrib_t&gt;'>
+    <metadata key='doc'><![CDATA[Additional metadata ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:242]]></metadata>
+
+    </field>
+    <field name='size' offset='64' type='/base/samples/frame/frame_size_t'>
+    <metadata key='doc'><![CDATA[The image size in pixels ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:245]]></metadata>
+
+    </field>
+    <field name='data_depth' offset='68' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[The number of effective bits per channel. The number
+of actual bits per channel is always a multiple of
+height (i.e. a 12-bit effective depth is represented
+using 16-bits per channels). The number of greyscale
+levels is 2^(this_number)]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:253]]></metadata>
+
+    </field>
+    <field name='pixel_size' offset='72' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[The size of one pixel, in bytes
+
+For instance, for a RGB image with a 8 bit data depth, it would
+be 3. For a 12 bit non-packed image (i.e with each channel
+encoded on 2 bytes), it would be 6.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:260]]></metadata>
+
+    </field>
+    <field name='row_size' offset='76' type='/uint32_t'>
+    <metadata key='doc'><![CDATA[The size of a complete row in bytes]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:264]]></metadata>
+
+    </field>
+    <field name='frame_mode' offset='80' type='/base/samples/frame/frame_mode_t'>
+    <metadata key='doc'><![CDATA[The colorspace of the image]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:268]]></metadata>
+
+    </field>
+    <field name='frame_status' offset='84' type='/base/samples/frame/frame_status_t'>
+    <metadata key='doc'><![CDATA[Status flag ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:271]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::Frame]]></metadata>
+<metadata key='doc'><![CDATA[A single image frame ]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:63]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/frame/FramePair' size='192'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:276]]></metadata>
+
+    </field>
+    <field name='first' offset='8' type='/base/samples/frame/Frame'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:277]]></metadata>
+
+    </field>
+    <field name='second' offset='96' type='/base/samples/frame/Frame'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:278]]></metadata>
+
+    </field>
+    <field name='id' offset='184' type='/uint32_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:279]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::frame::FramePair]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/samples/Frame.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/build_area/tidewise/wetpaint/install/base/types/include/base/samples/Frame.hpp:274]]></metadata>
+
+  </compound>
+  <compound name='/wrappers/AngleAxis&lt;/double&gt;' size='32'>
+    <field name='angle' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[store as angle and axis part, so it comes out clear in the pocosim logs]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:55]]></metadata>
+
+    </field>
+    <field name='axis' offset='8' type='/double[3]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:56]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::AngleAxis<double>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:52]]></metadata>
+
+  </compound>
+  <compound name='/wrappers/Matrix&lt;/double,2,1&gt;' size='16'>
+    <field name='data' offset='0' type='/double[2]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Vector2d]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 2, 1>]]></metadata>
+<metadata key='doc'><![CDATA[We define these typedefs to workaround alignment requirements for normal
+Eigen types. This reduces the amount of knowledge people have to have to
+manipulate these types -- as well as the structures that use them -- and
+make them usable in Orocos dataflow.
+
+Eigen supports converting them to "standard" eigen types in a
+straightforward way. Moreover, vectorization does not help for small
+sizes]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/AngleAxisd' source='/wrappers/AngleAxis&lt;/double&gt;'/>
+  <compound name='/wrappers/Matrix&lt;/double,2,2&gt;' size='32'>
+    <field name='data' offset='0' type='/double[4]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 2, 2>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Matrix2d' source='/wrappers/Matrix&lt;/double,2,2&gt;'/>
+  <compound name='/wrappers/Matrix&lt;/double,3,1&gt;' size='24'>
+    <field name='data' offset='0' type='/double[3]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Vector3d]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 3, 1>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/wrappers/Matrix&lt;/double,3,3&gt;' size='72'>
+    <field name='data' offset='0' type='/double[9]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Matrix3d]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 3, 3>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Matrix3d' source='/wrappers/Matrix&lt;/double,3,3&gt;'/>
+  <compound name='/wrappers/Matrix&lt;/double,4,1&gt;' size='32'>
+    <field name='data' offset='0' type='/double[4]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 4, 1>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/wrappers/Matrix&lt;/double,4,4&gt;' size='128'>
+    <field name='data' offset='0' type='/double[16]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 4, 4>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Matrix4d' source='/wrappers/Matrix&lt;/double,4,4&gt;'/>
+  <alias name='/wrappers/Matrix4x4d' source='/wrappers/Matrix&lt;/double,4,4&gt;'/>
+  <compound name='/wrappers/Matrix&lt;/double,6,1&gt;' size='48'>
+    <field name='data' offset='0' type='/double[6]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 6, 1>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <compound name='/wrappers/Matrix&lt;/double,6,6&gt;' size='288'>
+    <field name='data' offset='0' type='/double[36]'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Matrix6d]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::Matrix<double, 6, 6>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:12]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Matrix6d' source='/wrappers/Matrix&lt;/double,6,6&gt;'/>
+  <compound name='/wrappers/MatrixX&lt;/double&gt;' size='32'>
+    <field name='rows' offset='0' type='/int32_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:23]]></metadata>
+
+    </field>
+    <field name='cols' offset='4' type='/int32_t'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:24]]></metadata>
+
+    </field>
+    <field name='data' offset='8' type='/std/vector&lt;/double&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:25]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::MatrixX<double>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:20]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/MatrixXd' source='/wrappers/MatrixX&lt;/double&gt;'/>
+  <compound name='/wrappers/Quaternion&lt;/double&gt;' size='32'>
+    <field name='im' offset='0' type='/double[3]'>
+    <metadata key='doc'><![CDATA[store as imaginary and real part, so it comes out clear in the pocosim logs]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:44]]></metadata>
+
+    </field>
+    <field name='re' offset='24' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:45]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Quaterniond]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::Quaternion<double>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:41]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Vector2d' source='/wrappers/Matrix&lt;/double,2,1&gt;'/>
+  <alias name='/wrappers/Vector3d' source='/wrappers/Matrix&lt;/double,3,1&gt;'/>
+  <alias name='/wrappers/Vector4d' source='/wrappers/Matrix&lt;/double,4,1&gt;'/>
+  <alias name='/wrappers/Vector6d' source='/wrappers/Matrix&lt;/double,6,1&gt;'/>
+  <compound name='/wrappers/VectorX&lt;/double&gt;' size='24'>
+    <field name='data' offset='0' type='/std/vector&lt;/double&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:33]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::wrappers::VectorX<double>]]></metadata>
+<metadata key='opaque_is_typedef'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/Eigen.hpp:30]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Quaterniond' source='/wrappers/Quaternion&lt;/double&gt;'/>
+  <alias name='/wrappers/VectorXd' source='/wrappers/VectorX&lt;/double&gt;'/>
+  <compound name='/base/JointTransform_m' size='88'>
+    <field name='sourceFrame' offset='0' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransform.hpp:15]]></metadata>
+
+    </field>
+    <field name='targetFrame' offset='32' type='/std/string'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransform.hpp:16]]></metadata>
+
+    </field>
+    <field name='rotationAxis' offset='64' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransform.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::JointTransform]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::JointTransform_m]]></metadata>
+<metadata key='doc'><![CDATA[defines the frame transformation for a joint,
+and the rotation axis]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/JointTransform]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_JointTransform.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransform.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/Pose2D_m' size='24'>
+    <field name='position' offset='0' type='/wrappers/Matrix&lt;/double,2,1&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose2D.hpp:13]]></metadata>
+
+    </field>
+    <field name='orientation' offset='16' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose2D.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Pose2D]]></metadata>
+<metadata key='doc'><![CDATA[Representation for a pose in 2D]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/Pose2D]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Pose2D.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose2D.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/Pose_m' size='56'>
+    <field name='position' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose.hpp:13]]></metadata>
+
+    </field>
+    <field name='orientation' offset='24' type='/wrappers/Quaternion&lt;/double&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Pose]]></metadata>
+<metadata key='doc'><![CDATA[@brief Representation for a pose in 3D
+
+Stores the position and orientation part separately
+and is very well suited for storage and interchange,
+since it is a compact representation.]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/Pose]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Pose.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Pose.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/TransformWithCovariance_m' size='344'>
+    <field name='translation' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[The transformation is represented 6D vector [translation orientation]
+Here orientation is the rotational part expressed as a quaternion
+orientation, and t the translational component.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TransformWithCovariance.hpp:13]]></metadata>
+
+    </field>
+    <field name='orientation' offset='24' type='/wrappers/Quaternion&lt;/double&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TransformWithCovariance.hpp:14]]></metadata>
+
+    </field>
+    <field name='cov' offset='56' type='/wrappers/Matrix&lt;/double,6,6&gt;'>
+    <metadata key='doc'><![CDATA[The uncertainty is represented as a 6x6 matrix, which is the covariance
+matrix of the [translation orientation] representation of the error.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TransformWithCovariance.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::TransformWithCovariance]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::TransformWithCovariance_m]]></metadata>
+<metadata key='doc'><![CDATA[Class which represents a 3D Transformation with associated uncertainty information.
+
+The uncertainty is represented as a 6x6 matrix, which is the covariance
+matrix of the [r t] representation of the error. Here r is the rotation orientation
+part expressed as a scaled axis of orientation, and t the translational
+component.
+
+The uncertainty information is optional. The hasValidCovariance() method can
+be used to see if uncertainty information is associated with the class.]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/TransformWithCovariance]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_TransformWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TransformWithCovariance.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/TwistWithCovariance_m' size='336'>
+    <field name='vel' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Velocity in m/s ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TwistWithCovariance.hpp:13]]></metadata>
+
+    </field>
+    <field name='rot' offset='24' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Rotation rate in rad/s ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TwistWithCovariance.hpp:14]]></metadata>
+
+    </field>
+    <field name='cov' offset='48' type='/wrappers/Matrix&lt;/double,6,6&gt;'>
+    <metadata key='doc'><![CDATA[Uncertainty ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TwistWithCovariance.hpp:15]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::TwistWithCovariance]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::TwistWithCovariance_m]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/TwistWithCovariance]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_TwistWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_TwistWithCovariance.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/Waypoint_m' size='48'>
+    <field name='position' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Waypoint.hpp:13]]></metadata>
+
+    </field>
+    <field name='heading' offset='24' type='/double'>
+    <metadata key='doc'><![CDATA[heading in radians]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Waypoint.hpp:14]]></metadata>
+
+    </field>
+    <field name='tol_position' offset='32' type='/double'>
+    <metadata key='doc'><![CDATA[tollerance of the position in m]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Waypoint.hpp:15]]></metadata>
+
+    </field>
+    <field name='tol_heading' offset='40' type='/double'>
+    <metadata key='doc'><![CDATA[tollerance of the heading in rad]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Waypoint.hpp:16]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Waypoint]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::Waypoint_m]]></metadata>
+<metadata key='doc'><![CDATA[Representation for a pose]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/Waypoint]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Waypoint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Waypoint.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/Wrench_m' size='48'>
+    <field name='force' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Force in N ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Wrench.hpp:13]]></metadata>
+
+    </field>
+    <field name='torque' offset='24' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Torque in Nm]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Wrench.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Wrench]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::Wrench_m]]></metadata>
+<metadata key='doc'><![CDATA[Represents the force and torque applied at a point]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/Wrench]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Wrench.hpp:11]]></metadata>
+
+  </compound>
+  <compound name='/base/commands/LinearAngular6DCommand_m' size='56'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[The command timestamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_commands_LinearAngular6DCommand.hpp:15]]></metadata>
+
+    </field>
+    <field name='linear' offset='8' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[The linear part of the command, as (x,y,z) ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_commands_LinearAngular6DCommand.hpp:16]]></metadata>
+
+    </field>
+    <field name='angular' offset='32' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[The angular part of the command, as (r,p,y) ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_commands_LinearAngular6DCommand.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::commands::LinearAngular6DCommand]]></metadata>
+<metadata key='doc'><![CDATA[Common command structure for all controller types, in all control frames ]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/commands/LinearAngular6DCommand]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_commands_LinearAngular6DCommand.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_commands_LinearAngular6DCommand.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/BodyState_m' size='688'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Time-stamp ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_BodyState.hpp:16]]></metadata>
+
+    </field>
+    <field name='pose' offset='8' type='/base/TransformWithCovariance_m'>
+    <metadata key='doc'><![CDATA[Robot pose: rotation in radians and translation in meters ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_BodyState.hpp:17]]></metadata>
+
+    </field>
+    <field name='velocity' offset='352' type='/base/TwistWithCovariance_m'>
+    <metadata key='doc'><![CDATA[TwistWithCovariance: Linear[m/s] and Angular[rad/s] Velocity of the Body */
+It is assumed here that velocity is the derivative of a delta pose for
+a given interval. When such interval tends to zero, one could talk
+of instantaneous velocity ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_BodyState.hpp:18]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::BodyState]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the state of a rigid body
+
+This is among other things used to express frame transformations by
+Rock's transformer
+
+Given a source and target frame, this structure expresses the _frame
+change_ between these two frames. In effect, it represents the state of
+the source frame expressed in the target frame.
+
+Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards), you
+should use a X-forward, right handed coordinate system when assigning
+frames to bodies (i.e.  X=forward, Y=left, Z=up). In addition,
+world-fixed frames should be aligned to North (North-East-Up)
+
+For instance, if sourceFrame is "body" and targetFrame is "world", then
+the BodyState object is the state of body in the world frame
+(usually, the world frame has an arbitrary origin and a North-East-Up
+orientation).]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/BodyState]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_BodyState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_BodyState.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/IMUSensors_m' size='80'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Timestamp of the orientation reading ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_IMUSensors.hpp:15]]></metadata>
+
+    </field>
+    <field name='acc' offset='8' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[raw accelerometer readings ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_IMUSensors.hpp:16]]></metadata>
+
+    </field>
+    <field name='gyro' offset='32' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[raw gyro reading]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_IMUSensors.hpp:17]]></metadata>
+
+    </field>
+    <field name='mag' offset='56' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[raw magnetometer reading]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_IMUSensors.hpp:18]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::IMUSensors]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/IMUSensors]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_IMUSensors.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_IMUSensors.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/PoseWithCovariance_m' size='416'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='doc'><![CDATA[Reference timestamp of the pose sample ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_PoseWithCovariance.hpp:17]]></metadata>
+
+    </field>
+    <field name='frame_id' offset='8' type='/std/string'>
+    <metadata key='doc'><![CDATA[ID of the reference frame where this pose is expressed in ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_PoseWithCovariance.hpp:18]]></metadata>
+
+    </field>
+    <field name='object_frame_id' offset='40' type='/std/string'>
+    <metadata key='doc'><![CDATA[ID of the object frame defined by this pose ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_PoseWithCovariance.hpp:19]]></metadata>
+
+    </field>
+    <field name='transform' offset='72' type='/base/TransformWithCovariance_m'>
+    <metadata key='doc'><![CDATA[Pose of the object frame in the reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_PoseWithCovariance.hpp:20]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::PoseWithCovariance]]></metadata>
+<metadata key='doc'><![CDATA[Represents a 3D pose with uncertainty of the frame 'object_frame_id' in the frame 'frame_id'.
+A frame ID shall be globally unique and correspond to a coordinate system.
+Following the [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards)
+coordinate systems are right handed with X forward, Y left and Z up.
+
+The pose \f$ ^{reference}_{object}T \f$ in this structure transforms a vector \f$ v_{object} \f$
+from the object frame to the reference frame:
+\f$ v_{reference} = ^{reference}_{object}T \cdot v_{object} \f$
+Example of a transformation chain:
+\f$ ^{world}_{sensor}T = ^{world}_{body}T \cdot ^{body}_{sensor}T \f$]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/PoseWithCovariance]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_PoseWithCovariance.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_PoseWithCovariance.hpp:15]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/RigidBodyAcceleration_m' size='200'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:15]]></metadata>
+
+    </field>
+    <field name='acceleration' offset='8' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Linear acceleration in m/s2 ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:16]]></metadata>
+
+    </field>
+    <field name='cov_acceleration' offset='32' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the linear acceleration]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:17]]></metadata>
+
+    </field>
+    <field name='angular_acceleration' offset='104' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Angular acceleration in rad/s2 ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:18]]></metadata>
+
+    </field>
+    <field name='cov_angular_acceleration' offset='128' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the angular acceleration]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:19]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::RigidBodyAcceleration]]></metadata>
+<metadata key='doc'><![CDATA[Representation of accelerations of a body in a given (unspecified) fixed
+frame of reference
+
+While the frame of reference is unspecified, it will usually be the
+inertial frame. We encourage Rock code to use the body-fixed frame
+as the frame of expression.
+
+Indeed, Sensors (e.g. gyros, accelerometers) and models (e.g.
+hydrodynamic models) give access to velocities and accelerations w.r.t.
+the inertial frame, but expressed in the body frame. However, expressing
+the velocities/accelerations in the world frame from these
+sensing/estimation methods would require to have an estimate
+of the system's pose in the world, which is a harder thing to get.]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/RigidBodyAcceleration]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_RigidBodyAcceleration.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyAcceleration.hpp:13]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/RigidBodyState_m' size='464'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:17]]></metadata>
+
+    </field>
+    <field name='sourceFrame' offset='8' type='/std/string'>
+    <metadata key='doc'><![CDATA[Name of the source reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:18]]></metadata>
+
+    </field>
+    <field name='targetFrame' offset='40' type='/std/string'>
+    <metadata key='doc'><![CDATA[Name of the target reference frame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:19]]></metadata>
+
+    </field>
+    <field name='position' offset='72' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Position in m of sourceFrame's origin expressed in targetFrame]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:20]]></metadata>
+
+    </field>
+    <field name='cov_position' offset='96' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the position]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:21]]></metadata>
+
+    </field>
+    <field name='orientation' offset='168' type='/wrappers/Quaternion&lt;/double&gt;'>
+    <metadata key='doc'><![CDATA[Orientation of targetFrame expressed in sourceFrame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:22]]></metadata>
+
+    </field>
+    <field name='cov_orientation' offset='200' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance matrix of the orientation as an axis/angle manifold in
+body coordinates]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:23]]></metadata>
+
+    </field>
+    <field name='velocity' offset='272' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Velocity in m/s of sourceFrame relative to targetFrame,
+expressed in targetFrame ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:24]]></metadata>
+
+    </field>
+    <field name='cov_velocity' offset='296' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance of the velocity]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:25]]></metadata>
+
+    </field>
+    <field name='angular_velocity' offset='368' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Angular Velocity of sourceFrame relative to targetFrame,
+expressed in sourceFrame, as an axis-angle representation
+
+The direction of the vector is the axis, its length the speed ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:26]]></metadata>
+
+    </field>
+    <field name='cov_angular_velocity' offset='392' type='/wrappers/Matrix&lt;/double,3,3&gt;'>
+    <metadata key='doc'><![CDATA[Covariance of the angular velocity]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:27]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::RigidBodyState]]></metadata>
+<metadata key='doc'><![CDATA[Representation of the state of a rigid body
+
+This is among other things used to express frame transformations by
+Rock's transformer
+
+Given a source and target frame, this structure expresses the _frame
+change_ between these two frames. In effect, it represents the state of
+the source frame expressed in the target frame.
+
+Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards), you
+should use a X-forward, right handed coordinate system when assigning
+frames to bodies (i.e.  X=forward, Y=left, Z=up). In addition,
+world-fixed frames should be aligned to North (North-West-Up, aka NWU)
+
+For instance, if sourceFrame is "body" and targetFrame is "world", then
+the RigidBodyState object is the state of body in the world frame
+(usually, the world frame has an arbitrary origin and a North-West-Up
+orientation).]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/RigidBodyState]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_RigidBodyState.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_RigidBodyState.hpp:15]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Wrench_m' size='56'>
+    <field name='force' offset='0' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Force in N ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrench.hpp:15]]></metadata>
+
+    </field>
+    <field name='torque' offset='24' type='/wrappers/Matrix&lt;/double,3,1&gt;'>
+    <metadata key='doc'><![CDATA[Torque in Nm]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrench.hpp:16]]></metadata>
+
+    </field>
+    <field name='time' offset='48' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrench.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/Wrench]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Wrench]]></metadata>
+<metadata key='doc'><![CDATA[Wrench sample with Force, Torque and sampled Time]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/Wrench]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrench.hpp:13]]></metadata>
+
+  </compound>
+  <container kind='/std/vector' name='/std/vector&lt;/base/JointTransform_m&gt;' of='/base/JointTransform_m' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::JointTransform, std::allocator<base::JointTransform> >]]></metadata>
+<metadata key='cxxname'><![CDATA[::std::vector<base::JointTransform_m, std::allocator<base::JointTransform_m> >]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/std/vector</base/JointTransform>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_JointTransform.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Waypoint_m&gt;' of='/base/Waypoint_m' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Waypoint_m, std::allocator<base::Waypoint_m> >]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/std/vector</base/Waypoint>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Waypoint.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Wrench_m&gt;' of='/base/Wrench_m' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Wrench, std::allocator<base::Wrench> >]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/std/vector</base/Wrench>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Wrench.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/wrappers/Matrix&lt;/double,3,1&gt;&gt;' of='/wrappers/Matrix&lt;/double,3,1&gt;' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<wrappers::Matrix<double, 3, 1>, std::allocator<wrappers::Matrix<double, 3, 1> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <container kind='/std/vector' name='/std/vector&lt;/wrappers/Matrix&lt;/double,4,1&gt;&gt;' of='/wrappers/Matrix&lt;/double,4,1&gt;' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<wrappers::Matrix<double, 4, 1>, std::allocator<wrappers::Matrix<double, 4, 1> > >]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/Eigen.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <alias name='/std/orogen_typekits_mtype_std_vector_LT__base_JointTransform_GT_' source='/std/vector&lt;/base/JointTransform_m&gt;'/>
+  <alias name='/std/orogen_typekits_mtype_std_vector_LT__base_Waypoint_GT_' source='/std/vector&lt;/base/Waypoint_m&gt;'/>
+  <alias name='/std/orogen_typekits_mtype_std_vector_LT__base_Wrench_GT_' source='/std/vector&lt;/base/Wrench_m&gt;'/>
+  <alias name='/std/vector&lt;/wrappers/Vector4d&gt;' source='/std/vector&lt;/wrappers/Matrix&lt;/double,4,1&gt;&gt;'/>
+  <compound name='/base/JointTransformVector_m' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransformVector.hpp:16]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointTransform_m&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransformVector.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/JointTransform>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::JointTransformVector]]></metadata>
+<metadata key='doc'><![CDATA[Vector of JointTranformations with added functionality
+to fill a vector of RigidBodyStates given a jointsState sample]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/JointTransformVector]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_JointTransformVector.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_JointTransformVector.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector__base_JointTransform__m' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_JointTransform_GT_.hpp:16]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/JointTransform_m&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_JointTransform_GT_.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::JointTransform>]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/NamedVector</base/JointTransform>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_NamedVector_LT__base_JointTransform_GT_.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_JointTransform_GT_.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/NamedVector__base_Wrench__m' size='48'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_Wrench_GT_.hpp:16]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/Wrench_m&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_Wrench_GT_.hpp:17]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::NamedVector<base::Wrench>]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/NamedVector</base/Wrench>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_NamedVector_LT__base_Wrench_GT_.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_NamedVector_LT__base_Wrench_GT_.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Pointcloud_m' size='56'>
+    <field name='time' offset='0' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Pointcloud.hpp:16]]></metadata>
+
+    </field>
+    <field name='points' offset='8' type='/std/vector&lt;/wrappers/Matrix&lt;/double,3,1&gt;&gt;'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Pointcloud.hpp:17]]></metadata>
+
+    </field>
+    <field name='colors' offset='32' type='/std/vector&lt;/wrappers/Matrix&lt;/double,4,1&gt;&gt;'>
+    <metadata key='doc'><![CDATA[Colors of each point if available,
+leave empty if points are uncolored.
+Otherwise, it should have the same size
+as the points vector.]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Pointcloud.hpp:18]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::samples::Pointcloud]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/Pointcloud]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_Pointcloud.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Pointcloud.hpp:14]]></metadata>
+
+  </compound>
+  <compound name='/base/samples/Wrenches_m' size='56'>
+    <field name='names' offset='0' type='/std/vector&lt;/std/string&gt;'>
+    <metadata key='doc'><![CDATA[The names of the elements described in this structure, in the same
+order than the 'elements' field below]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrenches.hpp:18]]></metadata>
+
+    </field>
+    <field name='elements' offset='24' type='/std/vector&lt;/base/Wrench_m&gt;'>
+    <metadata key='doc'><![CDATA[The element vector ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrenches.hpp:19]]></metadata>
+
+    </field>
+    <field name='time' offset='48' type='/base/Time'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrenches.hpp:20]]></metadata>
+
+    </field>
+  <metadata key='base_classes'><![CDATA[/base/NamedVector</base/Wrench>]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::samples::Wrenches]]></metadata>
+<metadata key='doc'><![CDATA[A named vector of base::WrenchState with sampled Time.]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/samples/Wrenches]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_samples_Wrenches.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_samples_Wrenches.hpp:16]]></metadata>
+
+  </compound>
+  <alias name='/wrappers/Matrix&lt;/double,2,1&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,2,2&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,3,1&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,3,3&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,4,1&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,4,4&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,6,1&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/Matrix&lt;/double,6,6&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/MatrixX&lt;/double&gt;/Scalar' source='/double'/>
+  <alias name='/wrappers/VectorX&lt;/double&gt;/Scalar' source='/double'/>
+  <enum name='/wrappers/geometry/SplineType'>
+    <value symbol='DEGENERATE' value='0'/>
+    <value symbol='POLYNOMIAL_BEZIER' value='3'/>
+    <value symbol='POLYNOMIAL_BSPLINE' value='1'/>
+    <value symbol='RATIONAL_BEZIER' value='4'/>
+    <value symbol='RATIONAL_BSPLINE' value='2'/>
+  <metadata key='cxxname'><![CDATA[::wrappers::geometry::SplineType]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:14]]></metadata>
+
+  </enum>
+  <compound name='/wrappers/geometry/Spline' size='72'>
+    <field name='geometric_resolution' offset='0' type='/double'>
+    <metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:25]]></metadata>
+
+    </field>
+    <field name='dimension' offset='8' type='/int32_t'>
+    <metadata key='doc'><![CDATA[The dimension in which the curve lies ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:28]]></metadata>
+
+    </field>
+    <field name='curve_order' offset='12' type='/int32_t'>
+    <metadata key='doc'><![CDATA[The curve order ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:31]]></metadata>
+
+    </field>
+    <field name='kind' offset='16' type='/wrappers/geometry/SplineType'>
+    <metadata key='doc'><![CDATA[The type of the curve ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:34]]></metadata>
+
+    </field>
+    <field name='knots' offset='24' type='/std/vector&lt;/double&gt;'>
+    <metadata key='doc'><![CDATA[The curve knots. This is vertex_count + curve_order values ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:37]]></metadata>
+
+    </field>
+    <field name='vertices' offset='48' type='/std/vector&lt;/double&gt;'>
+    <metadata key='doc'><![CDATA[The vertices, as vertex_count * dimension coordinates if kind is
+non-rational and vertex_count * (dimension + 1) otherwise. ]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:41]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::geometry::Spline<3>]]></metadata>
+<metadata key='cxxname'><![CDATA[::wrappers::geometry::Spline]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/wrappers/geometry/Spline.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/base/wrappers/geometry/Spline.hpp:23]]></metadata>
+
+  </compound>
+  <compound name='/base/Trajectory_m' size='80'>
+    <field name='speed' offset='0' type='/double'>
+    <metadata key='doc'><![CDATA[The speed in which the trajectory should be
+traversed.
+]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Trajectory.hpp:13]]></metadata>
+
+    </field>
+    <field name='spline' offset='8' type='/wrappers/geometry/Spline'>
+    <metadata key='doc'><![CDATA[A spline representing the trajectory that should
+be driven.
+]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Trajectory.hpp:14]]></metadata>
+
+    </field>
+  <metadata key='cxxname'><![CDATA[::base::Trajectory]]></metadata>
+<metadata key='cxxname'><![CDATA[::base::Trajectory_m]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/base/Trajectory]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Trajectory.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/home/doudou/dev/tidewise/wetpaint/base/orogen/types/.orogen/typekit/types/base/m_types/base_Trajectory.hpp:11]]></metadata>
+
+  </compound>
+  <container kind='/std/vector' name='/std/vector&lt;/base/Trajectory_m&gt;' of='/base/Trajectory_m' size='24'>
+  <metadata key='cxxname'><![CDATA[::std::vector<base::Trajectory_m, std::allocator<base::Trajectory_m> >]]></metadata>
+<metadata key='orogen:intermediate_for'><![CDATA[/std/vector</base/Trajectory>]]></metadata>
+<metadata key='orogen:m_type'><![CDATA[1]]></metadata>
+<metadata key='orogen_defining_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_exporting_typekits'><![CDATA[base]]></metadata>
+<metadata key='orogen_include'><![CDATA[:vector]]></metadata>
+<metadata key='orogen_include'><![CDATA[base:base/m_types/base_Trajectory.hpp]]></metadata>
+<metadata key='source_file_line'><![CDATA[/usr/include/c++/9/bits/stl_vector.h:386]]></metadata>
+
+  </container>
+  <alias name='/std/orogen_typekits_mtype_std_vector_LT__base_Trajectory_GT_' source='/std/vector&lt;/base/Trajectory_m&gt;'/>
+</typelib>

--- a/bindings/ruby/test/typelib/test_spline.rb
+++ b/bindings/ruby/test/typelib/test_spline.rb
@@ -1,15 +1,11 @@
-require 'minitest/autorun'
-require 'orocos'
+require "minitest/autorun"
+require "typelib"
 
-describe 'typelib conversion for SISL splines' do
+describe "typelib conversion for SISL splines" do
     attr_reader :ruby_spline, :spline_t, :typelib_spline
     before do
-        if !Orocos.loaded?
-            Orocos.load
-        end
-        Orocos.load_typekit 'base'
-
-        @spline_t = Orocos.registry.get('/wrappers/geometry/Spline')
+        registry = Typelib::Registry.from_xml(File.read(File.join(__dir__, "base.tlb")))
+        @spline_t = registry.get("/wrappers/geometry/Spline")
         @ruby_spline = SISL::Spline.interpolate([[0,1], [2,3]])
         @typelib_spline = Typelib.from_ruby(ruby_spline, spline_t)
     end
@@ -18,20 +14,24 @@ describe 'typelib conversion for SISL splines' do
         typelib_spline.geometric_resolution = 2309
         spline = Typelib.to_ruby(typelib_spline)
         assert_kind_of SISL::Spline, spline
-        assert_equal typelib_spline.kind.to_s, spline_t.field_types['kind'].name_of(spline.sisl_curve_type)
+        assert_equal typelib_spline.kind.to_s,
+                     spline_t.field_types["kind"].name_of(spline.sisl_curve_type)
         assert_equal typelib_spline.dimension, spline.dimension
         assert_equal typelib_spline.geometric_resolution, spline.geometric_resolution
         assert_equal typelib_spline.knots.to_a, spline.knots
         assert_equal typelib_spline.vertices.to_a, spline.coordinates
-        
+
     end
+
     it "converts from the Ruby type to the typelib type" do
-        assert_equal spline_t.field_types['kind'].name_of(ruby_spline.sisl_curve_type), typelib_spline.kind.to_s
+        assert_equal spline_t.field_types["kind"].name_of(ruby_spline.sisl_curve_type),
+                     typelib_spline.kind.to_s
         assert_equal ruby_spline.dimension, typelib_spline.dimension
         assert_equal ruby_spline.geometric_resolution, typelib_spline.geometric_resolution
         assert_equal ruby_spline.knots, typelib_spline.knots.to_a
         assert_equal ruby_spline.coordinates, typelib_spline.vertices.to_a
     end
+
     it "creates a Spline3 object when converting a 3-dimensional spline" do
         ruby_spline = SISL::Spline.interpolate([[0,1,1], [2,3,3]])
         typelib_spline = Typelib.from_ruby(ruby_spline, spline_t)


### PR DESCRIPTION
This dependency is an issue because it creates a circular dependency.
The solution of moving these files to base/orogen/types is also
problematic since the typelib conversions can be used without the
typekit (e.g. analysing pocolog logs).

Copy the current state of `base.tlb` and use it directly. Since types
aren't meant to change often, I think it provides a good middle ground.