### PR TITLE
Include Euler angles rate vector to RBS data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*
 
 *autobuild-stamp
 
+.vscode/

--- a/src/samples/RigidBodyState.cpp
+++ b/src/samples/RigidBodyState.cpp
@@ -74,7 +74,7 @@ void RigidBodyState::setPose(const Pose& pose)
 
 Pose RigidBodyState::getPose() const
 {
-    return Pose( position, orientation );
+    return Pose(position, orientation);
 }
 
 double RigidBodyState::getYaw() const
@@ -169,25 +169,28 @@ bool RigidBodyState::isValidValue(const Vector3d& vec)
 bool RigidBodyState::isValidValue(const Orientation& ori)
 {
     return !isNaN(ori.w()) &&
-        !isNaN(ori.x()) &&
-        !isNaN(ori.y()) &&
-        !isNaN(ori.z()) &&
-        fabs(ori.squaredNorm()-1.0) < 1e-6;     //assuming at least single precision 
+           !isNaN(ori.x()) &&
+           !isNaN(ori.y()) &&
+           !isNaN(ori.z()) &&
+           fabs(ori.squaredNorm() - 1.0) < 1e-6;  //assuming at least single precision
 }
 
 bool RigidBodyState::isKnownValue(const Matrix3d& cov)
 {
-    return !isInfinity(cov(0,0)) &&
-        !isInfinity(cov(1,1)) &&
-        !isInfinity(cov(2,2));
+    return !isInfinity(cov(0, 0)) &&
+           !isInfinity(cov(1, 1)) &&
+           !isInfinity(cov(2, 2));
 }
 
 bool RigidBodyState::isValidCovariance(const Matrix3d& cov)
 {
-    for (int i = 0; i < 3; ++i)
-        for (int j = 0; j < 3; ++j)
-            if (isNaN(cov(i, j)))
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            if (isNaN(cov(i, j))) {
                 return false;
+            }
+        }
+    }
     return true;
 }
 
@@ -198,12 +201,12 @@ bool RigidBodyState::isValidValue(const Vector3d& vec, int dim)
 
 bool RigidBodyState::isValidCovariance(const Matrix3d& cov, int dim)
 {
-    return !isNaN(cov(dim,dim));
+    return !isNaN(cov(dim, dim));
 }
 
 bool RigidBodyState::isKnownValue(const Matrix3d& cov, int dim)
 {
-    return !isInfinity(cov(dim,dim));
+    return !isInfinity(cov(dim, dim));
 }
 
 Vector3d RigidBodyState::invalidValue()
@@ -263,7 +266,7 @@ bool RigidBodyState::hasValidOrientationCovariance() const
 
 void RigidBodyState::invalidateOrientation()
 {
-    orientation = invalidOrientation(); 
+    orientation = invalidOrientation();
 }
 
 void RigidBodyState::invalidateOrientationCovariance()
@@ -318,59 +321,25 @@ void RigidBodyState::invalidateAngularVelocity()
 
 void RigidBodyState::invalidateAngularVelocityCovariance()
 {
-    cov_angular_velocity = invalidCovariance(); 
+    cov_angular_velocity = invalidCovariance();
 }
 
-void RigidBodyState::invalidateValues(bool invPos, bool invOri, bool invVel, bool invAngVel)
+void RigidBodyState::invalidateValues(bool invPos, bool invOri, bool invVel,
+                                      bool invAngVel)
 {
-    if (invPos) invalidatePosition();
-    if (invOri) invalidateOrientation();
-    if (invVel) invalidateVelocity();
-    if (invAngVel) invalidateAngularVelocity();
+    if (invPos) { invalidatePosition(); }
+    if (invOri) { invalidateOrientation(); }
+    if (invVel) { invalidateVelocity(); }
+    if (invAngVel) { invalidateAngularVelocity(); }
 }
 
-void RigidBodyState::invalidateCovariances(bool invPos, bool invOri, bool invVel, bool invAngVel)
+void RigidBodyState::invalidateCovariances(bool invPos, bool invOri, bool invVel,
+                                           bool invAngVel)
 {
-    if (invPos) invalidatePositionCovariance();
-    if (invOri) invalidateOrientationCovariance();
-    if (invVel) invalidateVelocityCovariance();
-    if (invAngVel) invalidateAngularVelocityCovariance();
+    if (invPos) { invalidatePositionCovariance(); }
+    if (invOri) { invalidateOrientationCovariance(); }
+    if (invVel) { invalidateVelocityCovariance(); }
+    if (invAngVel) { invalidateAngularVelocityCovariance(); }
 }
-
-}} //end namespace base::samples
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+}  // end namespace samples
+}  // end namespace base

--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -8,12 +8,33 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 
-namespace base { namespace samples {
+namespace base {
+/**
+ * Maps angular velocity vector into Euler angles rate vector.
+ *
+ * It takes the provided orientation into account in order to map the provided angular
+ * velocity (represented by axis-angle) into Euler angles rate vector following the
+ * ZYX-order (yaw-pitch-roll).
+ */
+Vector3d angularVelocity2EulerRate(const Vector3d& angular_velocity,
+                                   const Orientation& orientation);
+
+/**
+ * Maps Euler angles rate vector into angular velocity vector.
+ *
+ * It takes the provided orientation into account in order to map the provided Euler
+ * rate vector following the ZYX-order (yaw-pitch-roll) into an angular velocity
+ * (represented by axis-angle).
+ */
+Vector3d eulerRate2AngularVelocity(const Vector3d& euler_rate,
+                                   const Orientation& orientation);
+
+namespace samples {
     /** Representation of the state of a rigid body
      *
      * This is among other things used to express frame transformations by
      * Rock's transformer
-     * 
+     *
      * Given a source and target frame, this structure expresses the _frame
      * change_ between these two frames. In effect, it represents the state of
      * the source frame expressed in the target frame.
@@ -94,6 +115,22 @@ namespace base { namespace samples {
 	    ret.translation() = this->position;
 	    return ret;
 	}
+
+        /** Gets the time derivative of the Euler angles ZYX (yaw-pitch-roll) */
+        base::Vector3d getEulerRate() const;
+
+        /** Gets yaw rate from getEulerRate()*/
+        double getYawRate() const;
+
+        /** Gets pitch rate from getEulerRate()*/
+        double getPitchRate() const;
+
+        /** Gets roll rate from getEulerRate()*/
+        double getRollRate() const;
+
+        /** Sets the angular velocity given the time derivative of Euler angles ZYX
+         *  (yaw-pitch-roll) */
+        void setAngularVelocity(const base::Vector3d& euler_rate);
 
         static RigidBodyState unknown();
 

--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -15,6 +15,13 @@ namespace base {
  * It takes the provided orientation into account in order to map the provided angular
  * velocity (represented by axis-angle) into Euler angles rate vector following the
  * ZYX-order (yaw-pitch-roll).
+ *
+ * It considers that "orientation" represents the orientation of the targetFrame
+ * expressed in the sourceFrame, the same way it is defined in RigidBodyState. The
+ * input angular_velocity is, then, considered to be expressed in the sourceFrame.
+ *
+ * For instance, if sourceFrame is "body" and targetFrame is "world", the input
+ * angular_velocity will be considered as being expressed in the "body" frame.
  */
 Vector3d angularVelocity2EulerRate(const Vector3d& angular_velocity,
                                    const Orientation& orientation);
@@ -25,6 +32,13 @@ Vector3d angularVelocity2EulerRate(const Vector3d& angular_velocity,
  * It takes the provided orientation into account in order to map the provided Euler
  * rate vector following the ZYX-order (yaw-pitch-roll) into an angular velocity
  * (represented by axis-angle).
+ *
+ * It considers that "orientation" represents the orientation of the targetFrame
+ * expressed in the sourceFrame, the same way it is defined in RigidBodyState. The
+ * resulting angular_velocity is, then, expressed in the sourceFrame.
+ *
+ * For instance, if sourceFrame is "body" and targetFrame is "world", the resulting
+ * angular velocity will be expressed in the "body" frame.
  */
 Vector3d eulerRate2AngularVelocity(const Vector3d& euler_rate,
                                    const Orientation& orientation);
@@ -39,8 +53,8 @@ namespace samples {
      * change_ between these two frames. In effect, it represents the state of
      * the source frame expressed in the target frame.
      *
-     * Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards), you
-     * should use a X-forward, right handed coordinate system when assigning
+     * Per [Rock's conventions](http://rock.opendfki.de/wiki/WikiStart/Standards),
+     * you should use a X-forward, right handed coordinate system when assigning
      * frames to bodies (i.e.  X=forward, Y=left, Z=up). In addition,
      * world-fixed frames should be aligned to North (North-West-Up, aka NWU)
      *

--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -51,36 +51,35 @@ namespace samples {
      */
     struct RigidBodyState
     {
-
         RigidBodyState(bool doInvalidation=true);
 
         base::Time time;
 
-	/** Name of the source reference frame */
-	std::string sourceFrame;
+        /** Name of the source reference frame */
+        std::string sourceFrame;
 
-	/** Name of the target reference frame */
-	std::string targetFrame;
+        /** Name of the target reference frame */
+        std::string targetFrame;
 
         /** Position in m of sourceFrame's origin expressed in targetFrame
          */
         Position   position;
-	/** Covariance matrix of the position
-	 */
+        /** Covariance matrix of the position
+         */
         base::Matrix3d cov_position;
 
         /** Orientation of targetFrame expressed in sourceFrame */
         Orientation orientation;
         /** Covariance matrix of the orientation as an axis/angle manifold in
          * body coordinates
-	 */
+         */
         base::Matrix3d cov_orientation;
 
         /** Velocity in m/s of sourceFrame relative to targetFrame,
          * expressed in targetFrame */
         base::Vector3d velocity;
-	/** Covariance of the velocity 
-	 */
+        /** Covariance of the velocity
+         */
         base::Matrix3d cov_velocity;
 
         /** Angular Velocity of sourceFrame relative to targetFrame,
@@ -89,32 +88,22 @@ namespace samples {
          * The direction of the vector is the axis, its length the speed */
         base::Vector3d angular_velocity;
         /** Covariance of the angular velocity
-	 */
+         */
         base::Matrix3d cov_angular_velocity;
 
-	void setTransform(const Eigen::Affine3d& transform);
+        void setTransform(const Eigen::Affine3d& transform);
 
-	 Eigen::Affine3d getTransform() const;
+        Eigen::Affine3d getTransform() const;
 
-	void setPose(const base::Pose& pose);
+        void setPose(const base::Pose& pose);
 
-	base::Pose getPose() const;
+        base::Pose getPose() const;
 
         double getYaw() const;
-	
+
         double getPitch() const;
-	
+
         double getRoll() const;
-	
-	template <int _Options>
-	operator Eigen::Transform<double, 3, Eigen::Affine, _Options>() const
-	{
-	    Eigen::Transform<double, 3, Eigen::Affine, _Options> ret;
-	    ret.setIdentity();
-	    ret.rotate(this->orientation);
-	    ret.translation() = this->position;
-	    return ret;
-	}
 
         /** Gets the time derivative of the Euler angles ZYX (yaw-pitch-roll) */
         base::Vector3d getEulerRate() const;
@@ -132,24 +121,34 @@ namespace samples {
          *  (yaw-pitch-roll) */
         void setAngularVelocity(const base::Vector3d& euler_rate);
 
+        template <int _Options>
+        operator Eigen::Transform<double, 3, Eigen::Affine, _Options>() const
+        {
+            Eigen::Transform<double, 3, Eigen::Affine, _Options> ret;
+            ret.setIdentity();
+            ret.rotate(this->orientation);
+            ret.translation() = this->position;
+            return ret;
+        }
+
         static RigidBodyState unknown();
 
         static RigidBodyState invalid();
-	
+
         /** For backward compatibility only. Use invalidate() */
         void initSane();
 
         /** Initializes the rigid body state with NaN for the
          * position, velocity, orientation and angular velocity.
          */
-	void invalidate();
-	
-	/**
+        void invalidate();
+
+        /**
          * Initializes the rigid body state unknown with Zero for the
          * position, velocity and angular velocity, Identity for the orientation
          * and infinity for all covariances.
          */
-	void initUnknown();
+        void initUnknown();
 
         /** Helper method that checks if a value is valid (not NaN anywhere). */
         static bool isValidValue(base::Vector3d const& vec);
@@ -184,7 +183,7 @@ namespace samples {
         static base::Matrix3d setValueUnknown();
 
         static base::Matrix3d invalidCovariance();
-	
+
         bool hasValidPosition() const;
         bool hasValidPosition(int idx) const;
         bool hasValidPositionCovariance() const;
@@ -214,6 +213,7 @@ namespace samples {
         void invalidateCovariances(bool invPos = true, bool invOri = true,
                                    bool invVel = true, bool invAngVel = true);
     };
-}}
+}  // end namespace samples
+}  // end namespace base
 
 #endif


### PR DESCRIPTION
This PR includes methods that provides conversions between angular velocity (axis-angle representation) and the corresponding ZYX Euler angles rate (commit https://github.com/rock-core/base-types/commit/d4c075e16d70b295c3c9ae7cf37c38cfa813f215) and also takes the opportunity to perform some style changes (commit https://github.com/rock-core/base-types/commit/6e6ef43df0324e513ce753ef247d34f95cc17320) based on `rock.vscode` linter suggestions.

The Euler angles rate can be very useful in some use-cases such as for trajectory planning and control and I thought it would be a good idea to centralize this functionality directly on RBS since the Euler angles (ZYX yaw-pitch-roll convention) are well defined there. 

Reference: https://opensource.docs.anymal.com/doxygen/kindr/master/cheatsheet_latest.pdf