### PR TITLE
add cmake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.8)
+project(base VERSION 1.0 DESCRIPTION "Common types for Rock systems")
+cmake_policy(SET CMP0057 NEW)
+
 find_package(Rock)
 rock_init(base 1.0)
 


### PR DESCRIPTION
It help keep existing projects building as new versions of
CMake introduce changes in behavior. In the scenario of the
base/types, the boost lib was crashing.