### PR TITLE
Automatically determine size of jpeg frames

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ rock_library(
         samples/Event.hpp
         samples/EventArray.hpp
         ${OPTIONAL_HPP}
+    DEPS_CMAKE JPEG
     DEPS_PKGCONFIG 
         base-logging
         eigen3

--- a/src/samples/Frame.cpp
+++ b/src/samples/Frame.cpp
@@ -365,8 +365,7 @@ void frame::Frame::setImage(const uint8_t* data, size_t newImageSize)
             jpeg_create_decompress(&dinfo);
             jpeg_mem_src(&dinfo, this->image.data(), this->image.size());
             jpeg_read_header(&dinfo, false);
-            jpeg_start_decompress(&dinfo);
-            this->size = frame_size_t(dinfo.output_width, dinfo.output_height);
+            this->size = frame_size_t(dinfo.image_width, dinfo.image_height);
             jpeg_destroy_decompress(&dinfo);
         }
     }


### PR DESCRIPTION
Sometimes, when reading a jpeg file you don't want to fully decompress it, but keep it as compressed imaged. `frame::Frame` still wants to know the size of the image, which can be determined using libjpeg.

Open points: 
* Shall this functionality be moved elsewhere? (e.g., `FrameHelper`)
* Additional functionality (maybe also in `FrameHelper`, such as `loadImageCompressed` which keeps the jpeg images in compressed mode)
* No specific error handling yet
* No unit test yet (I tested this with the `FrameHelper` test_suite, but did not make a PR for that)
 