### PR TITLE
RigidBodyStateVisualisation changes

### DIFF
--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -57,6 +57,7 @@ void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
         return;
     forcePositionDisplay = flag;
     emit propertyChanged("forcePositionDisplay");
+    updateModel();
 }
 bool RigidBodyStateVisualization::isOrientationDisplayForced() const
 { return forceOrientationDisplay; }
@@ -66,6 +67,7 @@ void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
         return;
     forceOrientationDisplay = flag;
     emit propertyChanged("forceOrientationDisplay");
+    updateModel();
 }
 
 void RigidBodyStateVisualization::setTexture(QString const& path)
@@ -226,6 +228,13 @@ ref_ptr<Group> RigidBodyStateVisualization::createSimpleBody(double size)
     return group;
 }
 
+void RigidBodyStateVisualization::updateModel() {
+    if (body_type == BODY_SIMPLE)
+        resetModel(total_size);
+    else if (body_type == BODY_SPHERE)
+        resetModelSphere(total_size);
+}
+
 double RigidBodyStateVisualization::getMainSphereSize() const
 {
     return main_size;
@@ -237,8 +246,7 @@ void RigidBodyStateVisualization::setMainSphereSize(double size)
         return;
     main_size = size;
     emit propertyChanged("sphereSize");
-    // This triggers an update of the model if we don't have a custom model
-    setSize(total_size);
+    updateModel();
 }
 
 double RigidBodyStateVisualization::getTextSize() const
@@ -252,8 +260,7 @@ void RigidBodyStateVisualization::setTextSize(double size)
         return;
     text_size = size;
     emit propertyChanged("textSize");
-    // This triggers an update of the model if we don't have a custom model
-    setSize(total_size);
+    updateModel();
 }
 
 void RigidBodyStateVisualization::setSize(double size)
@@ -262,10 +269,7 @@ void RigidBodyStateVisualization::setSize(double size)
         return;
     total_size = size;
     emit propertyChanged("size");
-    if (body_type == BODY_SIMPLE)
-        resetModel(size);
-    else if (body_type == BODY_SPHERE)
-        resetModelSphere(size);
+    updateModel();
 }
 
 double RigidBodyStateVisualization::getSize() const
@@ -372,6 +376,7 @@ void RigidBodyStateVisualization::displayCovariance(bool enable)
         return;
     covariance = enable;
     emit propertyChanged("displayCovariance");
+    updateModel();
 }
 bool RigidBodyStateVisualization::isCovarianceDisplayed() const
 { return covariance; }
@@ -385,6 +390,7 @@ void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
         return;
     covariance_with_samples = enable;
     emit propertyChanged("displayCovarianceWithSamples");
+    updateModel();
 }
 bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
 { return covariance_with_samples; }

--- a/viz/RigidBodyStateVisualization.cpp
+++ b/viz/RigidBodyStateVisualization.cpp
@@ -52,11 +52,21 @@ void RigidBodyStateVisualization::setColor(const Vec4d& color, Geode* geode)
 bool RigidBodyStateVisualization::isPositionDisplayForced() const
 { return forcePositionDisplay; }
 void RigidBodyStateVisualization::setPositionDisplayForceFlag(bool flag)
-{ forcePositionDisplay = flag; emit propertyChanged("forcePositionDisplay"); }
+{
+    if(forcePositionDisplay == flag)
+        return;
+    forcePositionDisplay = flag;
+    emit propertyChanged("forcePositionDisplay");
+}
 bool RigidBodyStateVisualization::isOrientationDisplayForced() const
 { return forceOrientationDisplay; }
 void RigidBodyStateVisualization::setOrientationDisplayForceFlag(bool flag)
-{ forceOrientationDisplay = flag; emit propertyChanged("forceOrientationDisplay"); }
+{
+    if(forceOrientationDisplay == flag)
+        return;
+    forceOrientationDisplay = flag;
+    emit propertyChanged("forceOrientationDisplay");
+}
 
 void RigidBodyStateVisualization::setTexture(QString const& path)
 { return setTexture(path.toStdString()); }
@@ -223,6 +233,8 @@ double RigidBodyStateVisualization::getMainSphereSize() const
 
 void RigidBodyStateVisualization::setMainSphereSize(double size)
 {
+    if(main_size == size)
+        return;
     main_size = size;
     emit propertyChanged("sphereSize");
     // This triggers an update of the model if we don't have a custom model
@@ -236,6 +248,8 @@ double RigidBodyStateVisualization::getTextSize() const
 
 void RigidBodyStateVisualization::setTextSize(double size)
 {
+    if(text_size == size)
+        return;
     text_size = size;
     emit propertyChanged("textSize");
     // This triggers an update of the model if we don't have a custom model
@@ -244,6 +258,8 @@ void RigidBodyStateVisualization::setTextSize(double size)
 
 void RigidBodyStateVisualization::setSize(double size)
 {
+    if(total_size == size)
+        return;
     total_size = size;
     emit propertyChanged("size");
     if (body_type == BODY_SIMPLE)
@@ -288,6 +304,9 @@ void RigidBodyStateVisualization::loadModel(QString const& path)
 
 void RigidBodyStateVisualization::loadModel(std::string const& path)
 {
+    if(model_path == QString::fromStdString(path))
+        return;
+    model_path = QString::fromStdString(path);
     if (path == "sphere")
     {
         resetModelSphere(total_size);
@@ -309,7 +328,6 @@ void RigidBodyStateVisualization::loadModel(std::string const& path)
     else if (!body_model->asGeode()->getDrawable(0)->asGeometry())
         std::cerr << "model does not contain a mesh, using bump mapping will not be possible" << std::endl;
 
-    model_path = QString::fromStdString(path);
     //set plugin name
     if(vizkit3d_plugin_name.isEmpty())
     {
@@ -349,7 +367,12 @@ void RigidBodyStateVisualization::setRotation(QQuaternion const& q)
 }
 
 void RigidBodyStateVisualization::displayCovariance(bool enable)
-{ covariance = enable; emit propertyChanged("displayCovariance"); }
+{
+    if(covariance == enable)
+        return;
+    covariance = enable;
+    emit propertyChanged("displayCovariance");
+}
 bool RigidBodyStateVisualization::isCovarianceDisplayed() const
 { return covariance; }
 
@@ -357,7 +380,12 @@ void RigidBodyStateVisualization::setColor(base::Vector3d const& color)
 { this->color = color; }
 
 void RigidBodyStateVisualization::displayCovarianceWithSamples(bool enable)
-{ covariance_with_samples = enable; emit propertyChanged("displayCovarianceWithSamples"); }
+{
+    if(covariance_with_samples == enable)
+        return;
+    covariance_with_samples = enable;
+    emit propertyChanged("displayCovarianceWithSamples");
+}
 bool RigidBodyStateVisualization::isCovarianceDisplayedWithSamples() const
 { return covariance_with_samples; }
 

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -137,6 +137,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
 	osg::ref_ptr<osg::Node>  body_model;
         osg::ref_ptr<osg::Group> createSimpleBody(double size);
 	osg::ref_ptr<osg::Group> createSimpleSphere(double size);
+        void updateModel();
 
         osg::ref_ptr<osg::Image> image;
         osg::ref_ptr<osg::Texture2D> texture;

--- a/viz/RigidBodyStateVisualization.hpp
+++ b/viz/RigidBodyStateVisualization.hpp
@@ -28,6 +28,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         Q_PROPERTY(bool forcePositionDisplay READ isPositionDisplayForced WRITE setPositionDisplayForceFlag)
         Q_PROPERTY(bool forceOrientationDisplay READ isOrientationDisplayForced WRITE setOrientationDisplayForceFlag)
         Q_PROPERTY(QString modelPath READ getModelPath WRITE loadModel)
+        Q_PROPERTY(bool displayTargetInSource READ isTargetInSourceShown WRITE setDisplayTargetInSource)
 
     public:
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -93,6 +94,9 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         void displayCovarianceWithSamples(bool enable);
         bool isCovarianceDisplayedWithSamples() const;
 
+        void setDisplayTargetInSource(bool enable);
+        bool isTargetInSourceShown() const;
+
         /** Sets the color of the default body model in R, G, B
          *
          * Values must be between 0 and 1
@@ -157,6 +161,7 @@ class RigidBodyStateVisualization : public Vizkit3DPlugin<base::samples::RigidBo
         
         QString model_path;
 
+        bool display_target_in_source;
 };
 
 }


### PR DESCRIPTION
This is a bit of a collection of cleanups and changes i had laying around. Instead of copying them around forever, i thought i would offer them here.

These should not change behavior, except: use less resources when a property is set to the same value it already has, update the displayed model when certain properties are changed(instead of relying on new data to do the same), or if the new displayTargetInSource property is used.