### PR TITLE
Add Logmessage type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ rock_library(
         JointsTrajectory.hpp
         JointTransform.hpp
         Logging.hpp
+        LogMessage.hpp
         Matrix.hpp
         NamedVector.hpp
         Point.hpp
@@ -114,7 +115,7 @@ rock_library(
         samples/Event.hpp
         samples/EventArray.hpp
         ${OPTIONAL_HPP}
-    DEPS_PKGCONFIG 
+    DEPS_PKGCONFIG
         base-logging
         eigen3
 )

--- a/src/LogMessage.hpp
+++ b/src/LogMessage.hpp
@@ -1,0 +1,24 @@
+#ifndef LOG_MESSAGE_HPP
+#define LOG_MESSAGE_HPP
+
+#include <string>
+#include <base/Time.hpp>
+
+namespace base
+{
+
+    /**
+     * @brief Log message type to be able to e.g. write timestamped messages/markers into log files
+     * 
+     */
+    class LogMessage
+    {
+        public:
+            base::Time timestamp;
+            std::string message;
+    };
+
+}
+
+#endif
+

--- a/src/LogMessage.hpp
+++ b/src/LogMessage.hpp
@@ -1,24 +1,22 @@
-#ifndef LOG_MESSAGE_HPP
-#define LOG_MESSAGE_HPP
+#ifndef WORKSPACE_BASE_TYPES_SRC_LOGMESSAGE_HPP_
+#define WORKSPACE_BASE_TYPES_SRC_LOGMESSAGE_HPP_
 
 #include <string>
-#include <base/Time.hpp>
+#include "./Time.hpp"
 
-namespace base
-{
+namespace base {
 
-    /**
-     * @brief Log message type to be able to e.g. write timestamped messages/markers into log files
-     * 
-     */
-    class LogMessage
-    {
-        public:
-            base::Time timestamp;
-            std::string message;
-    };
+/**
+ * @brief Log message type to be able to e.g. write timestamped messages/markers into log files
+ * 
+ */
+class LogMessage {
+ public:
+    base::Time time;
+    std::string message;
+};
 
-}
+}  // namespace base
 
-#endif
+#endif  // WORKSPACE_BASE_TYPES_SRC_LOGMESSAGE_HPP_
 

--- a/src/LogMessage.hpp
+++ b/src/LogMessage.hpp
@@ -2,7 +2,7 @@
 #define WORKSPACE_BASE_TYPES_SRC_LOGMESSAGE_HPP_
 
 #include <string>
-#include "./Time.hpp"
+#include <base/Time.hpp>
 
 namespace base {
 


### PR DESCRIPTION
Adds a LogMessage type (a timestamped string)

Provides ability to:
* put text-based markers into binary logs, like when an experiement started 
* use a port to show/record the time of state changes
* prepeares for an (to be published) orogen plugin that copies all stdout/stderr output to an output port to be able to print all output with an application rather than searching in the text log files
