### PR TITLE
Add serialization for Angle.hpp

### DIFF
--- a/src/Angle.hpp
+++ b/src/Angle.hpp
@@ -7,6 +7,7 @@
 #include <base/Eigen.hpp>
 
 #include <vector>
+#include <boost/serialization/serialization.hpp>
 
 namespace base
 {
@@ -343,6 +344,14 @@ public:
      * End angle of the segment
      * */
     double endRad;
+
+    // Serialization function
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version) {
+        ar & width;
+        ar & startRad;
+        ar & endRad;
+    }
 };
 
 std::ostream& operator << (std::ostream& os, AngleSegment seg);


### PR DESCRIPTION
Hello @planthaber,

I had to make the [TravNode.hpp](https://github.com/dfki-ric/traversability_generator3d/blob/5f5ae5278a1ad16ea67a1c68159813c21f4b0292/src/TravGenNode.hpp#L31) available over a rock port and it needs the Angle.hpp to be serialized.

Best,
Haider