### PR TITLE
chore: include meta flag for logical time in base samples

### DIFF
--- a/src/samples/Acceleration.hpp
+++ b/src/samples/Acceleration.hpp
@@ -9,6 +9,7 @@ namespace base { namespace samples {
 /** Spatial Acceleration with sampled time and frame ID*/
 struct Acceleration : public base::Acceleration
 {
+    /** @meta role logical_time */
     base::Time time;
     /** ID of the coordinate frame in which the spatial acceleration is expressed*/
     std::string frame_id;

--- a/src/samples/BodyState.hpp
+++ b/src/samples/BodyState.hpp
@@ -36,7 +36,10 @@ namespace base { namespace samples {
         BodyState(const base::TransformWithCovariance& pose, const base::TwistWithCovariance& velocity):
             pose(pose), velocity(velocity) {};
 
-        /** Time-stamp **/
+        /**
+         * Time-stamp
+         *
+         * @meta role logical_time */
         base::Time time;
 
         /** Robot pose: rotation in radians and translation in meters */

--- a/src/samples/BoundingBox.hpp
+++ b/src/samples/BoundingBox.hpp
@@ -62,7 +62,10 @@ struct BoundingBox {
      */
     bool hasValidCovDimension() const;
 
-    /* The sample timestamp. */
+    /**
+     * The sample timestamp.
+     *
+     * @meta role logical_time */
     Time time;
 
     /* 3D center (x, y, z) position of the bounding box . */

--- a/src/samples/DepthMap.hpp
+++ b/src/samples/DepthMap.hpp
@@ -61,7 +61,8 @@ public:
      * This timestamp is used for temporal alignment to other data samples
      * and transformations. 
      * It is important to always set here a meaningful value.
-     */
+     *
+     * @meta role logical_time */
     base::Time time;
     
     /** The timestamps can be either one timestamp for all measurements,

--- a/src/samples/DistanceImage.hpp
+++ b/src/samples/DistanceImage.hpp
@@ -34,6 +34,7 @@ namespace samples
     struct DistanceImage
     {
 	/// original timestamp of the camera image
+	/// @meta role logical_time
 	base::Time time;
 
 	/// width (x) value in pixels

--- a/src/samples/Event.hpp
+++ b/src/samples/Event.hpp
@@ -14,6 +14,7 @@ namespace samples {
 
         uint16_t x;
         uint16_t y;
+        /** @meta role logical_time */
         ::base::Time ts;
         uint8_t polarity;
     };

--- a/src/samples/EventArray.hpp
+++ b/src/samples/EventArray.hpp
@@ -9,6 +9,7 @@ namespace samples {
 
     struct EventArray
     {
+        /** @meta role logical_time */
         ::base::Time time;
         uint16_t height;
         uint16_t width;

--- a/src/samples/Frame.hpp
+++ b/src/samples/Frame.hpp
@@ -262,6 +262,8 @@ namespace base { namespace samples { namespace frame {
         /** The time at which this frame has been captured
          *
          * This is obviously an estimate
+         *
+         * @meta role logical_time
          */
         base::Time              time;
         /** The time at which this frame has been received on the system */

--- a/src/samples/IMUSensors.hpp
+++ b/src/samples/IMUSensors.hpp
@@ -7,7 +7,10 @@
 namespace base { namespace samples {
     struct IMUSensors
     {
-         /** Timestamp of the orientation reading */
+        /**
+         * Timestamp of the orientation reading
+         *
+         * @meta role logical_time */
         Time time;
 
         /** raw accelerometer readings */

--- a/src/samples/Joints.hpp
+++ b/src/samples/Joints.hpp
@@ -16,7 +16,10 @@ namespace base
          */
         struct Joints : public base::NamedVector<JointState>
         {
-            /** The sample timestamp */
+            /**
+             * The sample timestamp
+             *
+             * @meta role logical_time */
             base::Time time;
 
             static Joints Positions(std::vector<double> const& positions);

--- a/src/samples/LaserScan.hpp
+++ b/src/samples/LaserScan.hpp
@@ -26,7 +26,8 @@ namespace base { namespace samples {
         /** The timestamp of this reading. The timestamp is the time at which the
          * laser passed the zero step (i.e. the step at the back of the device,
          * which is distinct from the measurement 0)
-         */
+         *
+         * @meta role logical_time */
         Time time;
 
         /** The angle at which the range readings start. Zero is at the front of

--- a/src/samples/Pointcloud.hpp
+++ b/src/samples/Pointcloud.hpp
@@ -12,6 +12,7 @@ namespace base {
   namespace samples {
   struct Pointcloud
   {
+    /** @meta role logical_time */
     Time time;
 
     std::vector<base::Point> points;

--- a/src/samples/PoseWithCovariance.hpp
+++ b/src/samples/PoseWithCovariance.hpp
@@ -23,7 +23,10 @@ namespace base { namespace samples {
 class PoseWithCovariance
 {
 public:
-    /** Reference timestamp of the pose sample */
+    /**
+     * Reference timestamp of the pose sample
+     *
+     * @meta role logical_time */
     base::Time time;
 
     /** ID of the reference frame where this pose is expressed in */

--- a/src/samples/Pressure.hpp
+++ b/src/samples/Pressure.hpp
@@ -12,7 +12,10 @@ namespace base
         /** Timestamped pressure */
         struct Pressure : public base::Pressure
         {
-            /** The sample timestamp */
+            /**
+             * The sample timestamp
+             *
+             * @meta role logical_time */
             base::Time time;
 
             Pressure()

--- a/src/samples/RigidBodyAcceleration.hpp
+++ b/src/samples/RigidBodyAcceleration.hpp
@@ -24,6 +24,7 @@ namespace base { namespace samples {
     {
         RigidBodyAcceleration();
 
+        /** @meta role logical_time */
         base::Time time;
 
         /** Linear acceleration in m/s2 */

--- a/src/samples/RigidBodyState.hpp
+++ b/src/samples/RigidBodyState.hpp
@@ -67,6 +67,7 @@ namespace samples {
     {
         RigidBodyState(bool doInvalidation=true);
 
+        /** @meta role logical_time */
         base::Time time;
 
         /** Name of the source reference frame */

--- a/src/samples/RigidBodyStateSE3.hpp
+++ b/src/samples/RigidBodyStateSE3.hpp
@@ -9,6 +9,7 @@ namespace base{ namespace samples {
 /** RigidBodyStateSE3 with sampled time and frame ID*/
 struct RigidBodyStateSE3 : public base::RigidBodyStateSE3
 {
+    /** @meta role logical_time */
     base::Time time;
     /** Common coordinate frame for all quantities of the rigid body */
     std::string frame_id;

--- a/src/samples/RigidBodyStateSE3Vector.hpp
+++ b/src/samples/RigidBodyStateSE3Vector.hpp
@@ -10,6 +10,7 @@ namespace base { namespace samples {
 /** Named vector of base::RigidBodyStateSE3 with sampled Time. */
 struct RigidBodyStateSE3Vector : public base::NamedVector< base::RigidBodyStateSE3>
 {
+    /** @meta role logical_time */
     base::Time time;
     /** Common coordinate frame for all elements of the vector */
     std::string frame_id;

--- a/src/samples/Sonar.hpp
+++ b/src/samples/Sonar.hpp
@@ -63,7 +63,8 @@ public:
      * Advice: always set to a meaningful value as a lot of processing-related
      * algorithms expect one value. If you can't have *one*, then split your
      * scanning sonar into separate Sonar structure (one per beam).
-     */
+     *
+     * @meta role logical_time */
     base::Time time;
 
     /** The time at which the beam(s) acquisition started

--- a/src/samples/SonarBeam.hpp
+++ b/src/samples/SonarBeam.hpp
@@ -11,6 +11,7 @@ namespace base { namespace samples {
         typedef boost::uint8_t uint8_t;
 
         //timestamp of the sonar beam 
+        // @meta role logical_time
         Time time;
 
         //direction of the sonar beam in radians [-pi,+pi]

--- a/src/samples/SonarScan.hpp
+++ b/src/samples/SonarScan.hpp
@@ -97,6 +97,7 @@ namespace base { namespace samples {
             const uint8_t *getDataConstPtr() const;
 
             //The time at which this sonar scan has been captured
+            // @meta role logical_time
             base::Time                  time;
 
             //The raw data of the sonar scan

--- a/src/samples/Temperature.hpp
+++ b/src/samples/Temperature.hpp
@@ -10,7 +10,10 @@ namespace base
     {
         struct Temperature : public base::Temperature
         {
-            /** The sample timestamp */
+            /**
+             * The sample timestamp
+             *
+             * @meta role logical_time */
             base::Time time;
 
             Temperature() : base::Temperature() { }

--- a/src/samples/Twist.hpp
+++ b/src/samples/Twist.hpp
@@ -9,6 +9,7 @@ namespace base { namespace samples {
 /** Twist with sampled time and frame ID*/
 struct Twist : public base::Twist
 {
+    /** @meta role logical_time */
     base::Time time;
     /** ID of the coordinate frame in which the twist is expressed*/
     std::string frame_id;

--- a/src/samples/Wrench.hpp
+++ b/src/samples/Wrench.hpp
@@ -11,6 +11,7 @@ namespace base { namespace samples {
      */
     struct Wrench : public base::Wrench
     {
+        /** @meta role logical_time */
         base::Time time;
         /** ID of the coordinate frame in which the wrench is expressed*/
         std::string frame_id;

--- a/src/samples/Wrenches.hpp
+++ b/src/samples/Wrenches.hpp
@@ -12,6 +12,7 @@ namespace base { namespace samples {
      */
     struct Wrenches : public base::NamedVector< base::Wrench >
     {
+        /** @meta role logical_time */
         base::Time time;
     };
 }}


### PR DESCRIPTION
After this PR https://github.com/rock-core/tools-syskit/pull/452 
It is possible to signal to use the base::Time as logical time.

This PR, signals all the time fields in the base/samples that are supposed to be used as logical time when logging.

Obs: I tried to follow the same documentation style for each file... and tested that all of these styles flagas are detected.