### PR TITLE
fix: use bin count getter at sonar visualization

### DIFF
--- a/src/samples/Sonar.cpp
+++ b/src/samples/Sonar.cpp
@@ -163,7 +163,7 @@ void Sonar::validate()
         throw std::logic_error("the number of elements in 'bearings' does not match the beam count");
 }
 
-uint32_t Sonar::getBeamBinCount()
+uint32_t Sonar::getSingleBeamBinCount() const
 {
     return (bins.size() / beam_count);
 }

--- a/src/samples/Sonar.cpp
+++ b/src/samples/Sonar.cpp
@@ -163,7 +163,12 @@ void Sonar::validate()
         throw std::logic_error("the number of elements in 'bearings' does not match the beam count");
 }
 
-Sonar::Sonar(SonarScan const& old, float gain) 
+uint32_t Sonar::getBeamBinCount()
+{
+    return (bins.size() / beam_count);
+}
+
+Sonar::Sonar(SonarScan const& old, float gain)
     : time(old.time)
     , timestamps(old.time_beams)
     , bin_duration(Time::fromSeconds(old.getSpatialResolution() / old.speed_of_sound))

--- a/src/samples/Sonar.hpp
+++ b/src/samples/Sonar.hpp
@@ -116,8 +116,10 @@ public:
     
     /**
      * Number of bins in a beam
-     * 
-     * @deprecated, use getBeamBinCount() to return the number of bins in each beam
+     *
+     * @deprecated this field seem to be filled inconsistently across packages,
+     * and actually does not provide useful information. Use \c
+     * getSingleBeamBinCount() instead
      */
     uint32_t bin_count;
     
@@ -288,7 +290,7 @@ public:
      * Returns the number of bins in each beam
      * 
      */
-    uint32_t getBeamBinCount();
+    uint32_t getSingleBeamBinCount() const;
 
 BASE_TYPES_DEPRECATED_SUPPRESS_START
     explicit Sonar(SonarScan const& old, float gain = 1);

--- a/src/samples/Sonar.hpp
+++ b/src/samples/Sonar.hpp
@@ -114,7 +114,11 @@ public:
     /** The speed of sound in water at the time of acquisition and in m/s*/
     float speed_of_sound;
     
-    /** Number of bins in a beam */
+    /**
+     * Number of bins in a beam
+     * 
+     * @deprecated, use getBeamBinCount() to return the number of bins in each beam
+     */
     uint32_t bin_count;
     
     /** Number of beams in the structure */
@@ -279,6 +283,12 @@ public:
     /** Verify this structure's consistency
      */
     void validate();
+
+    /**
+     * Returns the number of bins in each beam
+     * 
+     */
+    uint32_t getBeamBinCount();
 
 BASE_TYPES_DEPRECATED_SUPPRESS_START
     explicit Sonar(SonarScan const& old, float gain = 1);

--- a/test/viz/test_sonar_visualization.rb
+++ b/test/viz/test_sonar_visualization.rb
@@ -20,7 +20,7 @@ module Vizkit
             sonar = Types.base.samples.Sonar.new
             sonar.speed_of_sound = 1000
             sonar.beam_count = beam_count
-            sonar.bin_count = bin_count
+            sonar.bin_count = beam_count*bin_count
             sonar.beam_width = Types.base.Angle.new
             sonar.beam_width.rad = 0.05
             sonar.bin_duration = Time.at(10.0/(sonar.speed_of_sound*sonar.bin_count/beam_count))

--- a/test/viz/test_sonar_visualization.rb
+++ b/test/viz/test_sonar_visualization.rb
@@ -20,7 +20,7 @@ module Vizkit
             sonar = Types.base.samples.Sonar.new
             sonar.speed_of_sound = 1000
             sonar.beam_count = beam_count
-            sonar.bin_count = beam_count*bin_count
+            sonar.bin_count = bin_count
             sonar.beam_width = Types.base.Angle.new
             sonar.beam_width.rad = 0.05
             sonar.bin_duration = Time.at(10.0/(sonar.speed_of_sound*sonar.bin_count/beam_count))

--- a/viz/SonarVisualization.cpp
+++ b/viz/SonarVisualization.cpp
@@ -67,7 +67,7 @@ void SonarVisualization::updateMainNode(osg::Node* node)
         right_beam_limit.makeRotate(last_sonar.bearings[i].rad + fan_opening/2.0, 
             osg::Vec3d(0,0,1));
         
-        int fan_segment = last_sonar.bin_count;
+        int fan_segment = last_sonar.getSingleBeamBinCount();
 
         for(size_t j = i*fan_segment; j < (i+1)*fan_segment; j++)
         {

--- a/viz/SonarVisualization.cpp
+++ b/viz/SonarVisualization.cpp
@@ -67,7 +67,7 @@ void SonarVisualization::updateMainNode(osg::Node* node)
         right_beam_limit.makeRotate(last_sonar.bearings[i].rad + fan_opening/2.0, 
             osg::Vec3d(0,0,1));
         
-        int fan_segment = last_sonar.bin_count/last_sonar.beam_count;
+        int fan_segment = last_sonar.bin_count;
 
         for(size_t j = i*fan_segment; j < (i+1)*fan_segment; j++)
         {


### PR DESCRIPTION
fix: remove division by bin_count in fan segment calculus
the bin_count inside a Sonar struct is the number of bins in each beam
<img width="560" height="96" alt="image" src="https://github.com/user-attachments/assets/8610febf-c3cb-4100-b7df-68fdc282f1b6" />
